### PR TITLE
Fix typescript problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "start": "wp-scripts start"
     },
     "devDependencies": {
+        "@types/lodash": "^4.14.202",
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.6",
         "@types/wordpress__block-editor": "^11.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ dependencies:
   '@fortawesome/react-fontawesome':
     specifier: ^0.2.0
     version: 0.2.0(@fortawesome/fontawesome-svg-core@6.5.1)(react@18.2.0)
-  '@types/wordpress__editor':
-    specifier: ^13.6.7
-    version: 13.6.7(react-dom@18.2.0)(react@18.2.0)
   '@wordpress/blob':
     specifier: ^3.37.0
     version: 3.37.0
@@ -55,6 +52,9 @@ dependencies:
     version: 18.2.0(react@18.2.0)
 
 devDependencies:
+  '@types/lodash':
+    specifier: ^4.14.202
+    version: 4.14.202
   '@types/react':
     specifier: ^18.2.14
     version: 18.2.14
@@ -67,6 +67,9 @@ devDependencies:
   '@types/wordpress__blocks':
     specifier: ^12.5.4
     version: 12.5.4(react-dom@18.2.0)(react@18.2.0)
+  '@types/wordpress__editor':
+    specifier: ^13.6.7
+    version: 13.6.7(react-dom@18.2.0)(react@18.2.0)
   '@wordpress/base-styles':
     specifier: ^4.39.0
     version: 4.39.0
@@ -98,7 +101,6 @@ packages:
 
   /@ariakit/core@0.3.10:
     resolution: {integrity: sha512-AcN+GSoVXuUOzKx5d3xPL3YsEHevh4PIO6QIt/mg/nRX1XQ6cvxQEiAjO/BJQm+/MVl7/VbuGBoTFjr0tPU6NQ==}
-    dev: false
 
   /@ariakit/react-core@0.2.12(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-3KSKlX10nnhCvjsbPW0CAnqG+6grryfwnMkeJJ/h34FSV7hEfUMexmIjKBVZyfBG08Xj8NjSK8kkx9c3ChkXeA==}
@@ -124,7 +126,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       use-sync-external-store: 1.2.0(react@18.2.0)
-    dev: false
 
   /@ariakit/react@0.2.12(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-4rAgMyUURHW78EKgRCanhyRUtsiYCOxO65BBHF4mg3tZsDeOvu9kBG5IAXX8mUgakTcyr0EKXuOtGThaj7gobA==}
@@ -146,7 +147,6 @@ packages:
       '@ariakit/react-core': 0.3.12(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@babel/code-frame@7.22.5:
     resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
@@ -1540,7 +1540,6 @@ packages:
       find-root: 1.1.0
       source-map: 0.5.7
       stylis: 4.2.0
-    dev: false
 
   /@emotion/cache@11.11.0:
     resolution: {integrity: sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==}
@@ -1550,7 +1549,6 @@ packages:
       '@emotion/utils': 1.2.1
       '@emotion/weak-memoize': 0.3.1
       stylis: 4.2.0
-    dev: false
 
   /@emotion/css@11.11.2:
     resolution: {integrity: sha512-VJxe1ucoMYMS7DkiMdC2T7PWNbrEI0a39YRiyDvK2qq4lXwjRbVP/z4lpG+odCsRzadlR+1ywwrTzhdm5HNdew==}
@@ -1560,35 +1558,29 @@ packages:
       '@emotion/serialize': 1.1.2
       '@emotion/sheet': 1.2.2
       '@emotion/utils': 1.2.1
-    dev: false
 
   /@emotion/hash@0.9.1:
     resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
-    dev: false
 
   /@emotion/is-prop-valid@0.8.8:
     resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
     requiresBuild: true
     dependencies:
       '@emotion/memoize': 0.7.4
-    dev: false
     optional: true
 
   /@emotion/is-prop-valid@1.2.1:
     resolution: {integrity: sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==}
     dependencies:
       '@emotion/memoize': 0.8.1
-    dev: false
 
   /@emotion/memoize@0.7.4:
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /@emotion/memoize@0.8.1:
     resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
-    dev: false
 
   /@emotion/react@11.11.1(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==}
@@ -1609,7 +1601,6 @@ packages:
       '@types/react': 18.2.14
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
-    dev: false
 
   /@emotion/serialize@1.1.2:
     resolution: {integrity: sha512-zR6a/fkFP4EAcCMQtLOhIgpprZOwNmCldtpaISpvz348+DP4Mz8ZoKaGGCQpbzepNIUWbq4w6hNZkwDyKoS+HA==}
@@ -1619,11 +1610,9 @@ packages:
       '@emotion/unitless': 0.8.1
       '@emotion/utils': 1.2.1
       csstype: 3.1.2
-    dev: false
 
   /@emotion/sheet@1.2.2:
     resolution: {integrity: sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==}
-    dev: false
 
   /@emotion/styled@11.11.0(@emotion/react@11.11.1)(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==}
@@ -1644,11 +1633,9 @@ packages:
       '@emotion/utils': 1.2.1
       '@types/react': 18.2.14
       react: 18.2.0
-    dev: false
 
   /@emotion/unitless@0.8.1:
     resolution: {integrity: sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==}
-    dev: false
 
   /@emotion/use-insertion-effect-with-fallbacks@1.0.1(react@18.2.0):
     resolution: {integrity: sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==}
@@ -1656,15 +1643,12 @@ packages:
       react: '>=16.8.0'
     dependencies:
       react: 18.2.0
-    dev: false
 
   /@emotion/utils@1.2.1:
     resolution: {integrity: sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==}
-    dev: false
 
   /@emotion/weak-memoize@0.3.1:
     resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
-    dev: false
 
   /@es-joy/jsdoccomment@0.36.1:
     resolution: {integrity: sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==}
@@ -1714,23 +1698,19 @@ packages:
 
   /@floating-ui/core@0.7.3:
     resolution: {integrity: sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg==}
-    dev: false
 
   /@floating-ui/core@1.3.1:
     resolution: {integrity: sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g==}
-    dev: false
 
   /@floating-ui/dom@0.5.4:
     resolution: {integrity: sha512-419BMceRLq0RrmTSDxn8hf9R3VCJv2K9PUfugh5JyEFmdjzDo+e8U5EdR8nzKq8Yj1htzLm3b6eQEEam3/rrtg==}
     dependencies:
       '@floating-ui/core': 0.7.3
-    dev: false
 
   /@floating-ui/dom@1.4.5:
     resolution: {integrity: sha512-96KnRWkRnuBSSFbj0sFGwwOUd8EkiecINVl0O9wiZlZ64EkpyAOG3Xc2vKKNJmru0Z7RqWNymA+6b8OZqjgyyw==}
     dependencies:
       '@floating-ui/core': 1.3.1
-    dev: false
 
   /@floating-ui/react-dom@0.7.2(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-1T0sJcpHgX/u4I1OzIEhlcrvkUN8ln39nz7fMoE/2HDHrPiMFoOGR7++GYyfUmIQHkkrTinaeQsO3XWubjSvGg==}
@@ -1744,7 +1724,6 @@ packages:
       use-isomorphic-layout-effect: 1.1.2(@types/react@18.2.14)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
-    dev: false
 
   /@floating-ui/react-dom@1.0.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-uiOalFKPG937UCLm42RxjESTWUVpbbatvlphQAU6bsv+ence6IoVG8JOUZcy8eW81NkU+Idiwvx10WFLmR4MIg==}
@@ -1766,7 +1745,6 @@ packages:
       '@floating-ui/dom': 1.4.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@fortawesome/fontawesome-common-types@6.5.1:
     resolution: {integrity: sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==}
@@ -2183,13 +2161,11 @@ packages:
 
   /@popperjs/core@2.11.8:
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
-    dev: false
 
   /@radix-ui/primitive@1.0.0:
     resolution: {integrity: sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==}
     dependencies:
       '@babel/runtime': 7.22.5
-    dev: false
 
   /@radix-ui/primitive@1.0.1:
     resolution: {integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==}
@@ -2207,7 +2183,6 @@ packages:
       '@radix-ui/react-primitive': 1.0.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@radix-ui/react-arrow@1.0.3(@types/react-dom@18.2.6)(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==}
@@ -2243,7 +2218,6 @@ packages:
       '@radix-ui/react-slot': 1.0.1(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@radix-ui/react-collection@1.0.3(@types/react-dom@18.2.6)(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==}
@@ -2276,7 +2250,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       react: 18.2.0
-    dev: false
 
   /@radix-ui/react-compose-refs@1.0.1(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==}
@@ -2299,7 +2272,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       react: 18.2.0
-    dev: false
 
   /@radix-ui/react-context@1.0.1(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==}
@@ -2340,7 +2312,6 @@ packages:
       react-remove-scroll: 2.5.4(@types/react@18.2.14)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
-    dev: false
 
   /@radix-ui/react-direction@1.0.0(react@18.2.0):
     resolution: {integrity: sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==}
@@ -2349,7 +2320,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       react: 18.2.0
-    dev: false
 
   /@radix-ui/react-direction@1.0.1(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==}
@@ -2379,7 +2349,6 @@ packages:
       '@radix-ui/react-use-escape-keydown': 1.0.0(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@radix-ui/react-dismissable-layer@1.0.3(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-nXZOvFjOuHS1ovumntGV7NNoLaEp9JEvTht3MBjP44NSW5hUKj/8OnfN3+8WmB+CEhN44XaGhpHoSsUIEl5P7Q==}
@@ -2395,7 +2364,6 @@ packages:
       '@radix-ui/react-use-escape-keydown': 1.0.2(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@radix-ui/react-dismissable-layer@1.0.4(@types/react-dom@18.2.6)(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-7UpBa/RKMoHJYjie1gkF1DlK8l1fdU/VKDpoS3rCCo8YBJR294GwcEHyxHw72yvphJ7ld0AXEcSLAzY2F/WyCg==}
@@ -2440,7 +2408,6 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
-    dev: false
 
   /@radix-ui/react-dropdown-menu@2.0.5(@types/react-dom@18.2.6)(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-xdOrZzOTocqqkCkYo8yRPCib5OkTkqN7lqNCdxwPOdE466DOaNl4N8PkUIlsXthQvW5Wwkd+aEmWpfWlBoDPEw==}
@@ -2476,7 +2443,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       react: 18.2.0
-    dev: false
 
   /@radix-ui/react-focus-guards@1.0.1(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==}
@@ -2504,7 +2470,6 @@ packages:
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@radix-ui/react-focus-scope@1.0.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-spwXlNTfeIprt+kaEWE/qYuYT3ZAqJiAGjN/JgdvgVDTu8yc+HuX+WOWXrKliKnLnwck0F6JDkqIERncnih+4A==}
@@ -2518,7 +2483,6 @@ packages:
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@radix-ui/react-focus-scope@1.0.3(@types/react-dom@18.2.6)(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-upXdPfqI4islj2CslyfUBNlaJCPybbqRHAi1KER7Isel9Q2AtSJ0zRBZv8mWQiFXD2nyAJ4BhC3yXgZ6kMBSrQ==}
@@ -2551,7 +2515,6 @@ packages:
       '@babel/runtime': 7.22.5
       '@radix-ui/react-use-layout-effect': 1.0.0(react@18.2.0)
       react: 18.2.0
-    dev: false
 
   /@radix-ui/react-id@1.0.1(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==}
@@ -2597,7 +2560,6 @@ packages:
       react-remove-scroll: 2.5.5(@types/react@18.2.14)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
-    dev: false
 
   /@radix-ui/react-menu@2.0.5(@types/react-dom@18.2.6)(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-Gw4f9pwdH+w5w+49k0gLjN0PfRDHvxmAgG16AbyJZ7zhwZ6PBHKtWohvnSwfusfnK3L68dpBREHpVkj8wEM7ZA==}
@@ -2658,7 +2620,6 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
-    dev: false
 
   /@radix-ui/react-popper@1.1.2(@types/react-dom@18.2.6)(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-1CnGGfFi/bbqtJZZ0P/NQY20xdG3E0LALJaLUEoKwPLwl6PPPfbeiCqMVQnhoFRAxjJj4RpBRJzDmUgsex2tSg==}
@@ -2700,7 +2661,6 @@ packages:
       '@radix-ui/react-primitive': 1.0.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@radix-ui/react-portal@1.0.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-swu32idoCW7KA2VEiUZGBSu9nB6qwGdV6k6HYhUoOo3M1FFpD+VgLzUqtt3mwL1ssz7r2x8MggpLSQach2Xy/Q==}
@@ -2712,7 +2672,6 @@ packages:
       '@radix-ui/react-primitive': 1.0.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@radix-ui/react-portal@1.0.3(@types/react-dom@18.2.6)(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-xLYZeHrWoPmA5mEKEfZZevoVRK/Q43GfzRXkWV6qawIWWK8t6ifIiLQdd7rmQ4Vk1bmI21XhqF9BN3jWf+phpA==}
@@ -2746,7 +2705,6 @@ packages:
       '@radix-ui/react-use-layout-effect': 1.0.0(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@radix-ui/react-presence@1.0.1(@types/react-dom@18.2.6)(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==}
@@ -2780,7 +2738,6 @@ packages:
       '@radix-ui/react-slot': 1.0.0(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@radix-ui/react-primitive@1.0.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-zY6G5Qq4R8diFPNwtyoLRZBxzu1Z+SXMlfYpChN7Dv8gvmx9X3qhDqiLWvKseKVJMuedFeU/Sa0Sy/Ia+t06Dw==}
@@ -2792,7 +2749,6 @@ packages:
       '@radix-ui/react-slot': 1.0.1(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@radix-ui/react-primitive@1.0.3(@types/react-dom@18.2.6)(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==}
@@ -2833,7 +2789,6 @@ packages:
       '@radix-ui/react-use-controllable-state': 1.0.0(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@radix-ui/react-roving-focus@1.0.4(@types/react-dom@18.2.6)(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==}
@@ -2872,7 +2827,6 @@ packages:
       '@babel/runtime': 7.22.5
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       react: 18.2.0
-    dev: false
 
   /@radix-ui/react-slot@1.0.1(react@18.2.0):
     resolution: {integrity: sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==}
@@ -2882,7 +2836,6 @@ packages:
       '@babel/runtime': 7.22.5
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       react: 18.2.0
-    dev: false
 
   /@radix-ui/react-slot@1.0.2(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}
@@ -2906,7 +2859,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       react: 18.2.0
-    dev: false
 
   /@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==}
@@ -2930,7 +2882,6 @@ packages:
       '@babel/runtime': 7.22.5
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.2.0)
       react: 18.2.0
-    dev: false
 
   /@radix-ui/react-use-controllable-state@1.0.1(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==}
@@ -2955,7 +2906,6 @@ packages:
       '@babel/runtime': 7.22.5
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.2.0)
       react: 18.2.0
-    dev: false
 
   /@radix-ui/react-use-escape-keydown@1.0.2(react@18.2.0):
     resolution: {integrity: sha512-DXGim3x74WgUv+iMNCF+cAo8xUHHeqvjx8zs7trKf+FkQKPQXLk2sX7Gx1ysH7Q76xCpZuxIJE7HLPxRE+Q+GA==}
@@ -2965,7 +2915,6 @@ packages:
       '@babel/runtime': 7.22.5
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.2.0)
       react: 18.2.0
-    dev: false
 
   /@radix-ui/react-use-escape-keydown@1.0.3(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==}
@@ -2989,7 +2938,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       react: 18.2.0
-    dev: false
 
   /@radix-ui/react-use-layout-effect@1.0.1(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==}
@@ -3013,7 +2961,6 @@ packages:
       '@babel/runtime': 7.22.5
       '@radix-ui/rect': 1.0.0
       react: 18.2.0
-    dev: false
 
   /@radix-ui/react-use-rect@1.0.1(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-Cq5DLuSiuYVKNU8orzJMbl15TXilTnJKUCltMVQg53BQOF1/C5toAaGrowkgksdBQ9H+SRL23g0HDmg9tvmxXw==}
@@ -3038,7 +2985,6 @@ packages:
       '@babel/runtime': 7.22.5
       '@radix-ui/react-use-layout-effect': 1.0.0(react@18.2.0)
       react: 18.2.0
-    dev: false
 
   /@radix-ui/react-use-size@1.0.1(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-ibay+VqrgcaI6veAojjofPATwledXiSmX+C0KrBk/xgpX9rBzPV3OsfwlhQdUOFbh+LKQorLYT+xTXW9V8yd0g==}
@@ -3059,7 +3005,6 @@ packages:
     resolution: {integrity: sha512-d0O68AYy/9oeEy1DdC07bz1/ZXX+DqCskRd3i4JzLSTXwefzaepQrKjXC7aNM8lTHjFLDO0pDgaEiQ7jEk+HVg==}
     dependencies:
       '@babel/runtime': 7.22.5
-    dev: false
 
   /@radix-ui/rect@1.0.1:
     resolution: {integrity: sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==}
@@ -3075,7 +3020,6 @@ packages:
       '@react-spring/shared': 9.7.3(react@18.2.0)
       '@react-spring/types': 9.7.3
       react: 18.2.0
-    dev: false
 
   /@react-spring/core@9.7.3(react@18.2.0):
     resolution: {integrity: sha512-IqFdPVf3ZOC1Cx7+M0cXf4odNLxDC+n7IN3MDcVCTIOSBfqEcBebSv+vlY5AhM0zw05PDbjKrNmBpzv/AqpjnQ==}
@@ -3086,7 +3030,6 @@ packages:
       '@react-spring/shared': 9.7.3(react@18.2.0)
       '@react-spring/types': 9.7.3
       react: 18.2.0
-    dev: false
 
   /@react-spring/shared@9.7.3(react@18.2.0):
     resolution: {integrity: sha512-NEopD+9S5xYyQ0pGtioacLhL2luflh6HACSSDUZOwLHoxA5eku1UPuqcJqjwSD6luKjjLfiLOspxo43FUHKKSA==}
@@ -3095,11 +3038,9 @@ packages:
     dependencies:
       '@react-spring/types': 9.7.3
       react: 18.2.0
-    dev: false
 
   /@react-spring/types@9.7.3:
     resolution: {integrity: sha512-Kpx/fQ/ZFX31OtlqVEFfgaD1ACzul4NksrvIgYfIFq9JpDHFwQkMVZ10tbo0FU/grje4rcL4EIrjekl3kYwgWw==}
-    dev: false
 
   /@react-spring/web@9.7.3(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-BXt6BpS9aJL/QdVqEIX9YoUy8CE6TJrU0mNCqSoxdXlIeNcEBWOfIyE6B14ENNsyQKS3wOWkiJfco0tCr/9tUg==}
@@ -3113,7 +3054,6 @@ packages:
       '@react-spring/types': 9.7.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@sideway/address@4.1.4:
     resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}
@@ -3431,11 +3371,9 @@ packages:
 
   /@types/gradient-parser@0.1.3:
     resolution: {integrity: sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ==}
-    dev: false
 
   /@types/highlight-words-core@1.2.1:
     resolution: {integrity: sha512-9VZUA5omXBfn+hDxFjUDu1FOJTBM3LmvqfDey+Z6Aa8B8/JmF5SMj6FBrjfgJ/Q3YXOZd3qyTDfJyMZSs/wCUA==}
-    dev: false
 
   /@types/http-errors@2.0.1:
     resolution: {integrity: sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==}
@@ -3477,6 +3415,10 @@ packages:
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+    dev: true
+
+  /@types/lodash@4.14.202:
+    resolution: {integrity: sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==}
     dev: true
 
   /@types/mime@1.3.2:
@@ -3527,7 +3469,7 @@ packages:
     resolution: {integrity: sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==}
     dependencies:
       '@types/react': 17.0.74
-    dev: false
+    dev: true
 
   /@types/react-dom@18.2.6:
     resolution: {integrity: sha512-2et4PDvg6PVCyS7fuTc4gPoksV58bW0RwSxWKcPRcHZf0PRUGq03TKcD/rUHe3azfV6/5/biUBJw+HhCQjaP0A==}
@@ -3540,7 +3482,7 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.3
       csstype: 3.1.2
-    dev: false
+    dev: true
 
   /@types/react@18.2.14:
     resolution: {integrity: sha512-A0zjq+QN/O0Kpe30hA1GidzyFjatVvrpIvWLxD+xv67Vt91TWWgco9IvrJBkeyHm1trGaFS/FSGqPlhyeZRm0g==}
@@ -3585,7 +3527,6 @@ packages:
     resolution: {integrity: sha512-rvqefdp2rvIA6wiomMgKWd2UZNPe6LM2EV5AuY3CPQJF+8TbdrL5TjYdMf0VAjGczzlkH4l1NjDkihwbj3Xodw==}
     dependencies:
       '@types/node': 20.3.2
-    dev: false
 
   /@types/sockjs@0.3.33:
     resolution: {integrity: sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==}
@@ -3607,6 +3548,7 @@ packages:
 
   /@types/tinycolor2@1.4.3:
     resolution: {integrity: sha512-Kf1w9NE5HEgGxCRyIcRXR/ZYtDv0V8FVPtYHwLxl0O+maGX0erE77pQlD0gpP+/KByMZ87mOA79SjifhSB3PjQ==}
+    dev: true
 
   /@types/tough-cookie@4.0.2:
     resolution: {integrity: sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==}
@@ -3650,6 +3592,7 @@ packages:
     transitivePeerDependencies:
       - react
       - react-dom
+    dev: true
 
   /@types/wordpress__blocks@12.5.4(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-urnz5QVqa+SfMrfMEI8L31LKAR7Gk9YmOY95kK4lhhwvSvTw3AeFfaX2JOW8ubNRxQbBNkQqexeJywaUa6CCYg==}
@@ -3662,6 +3605,7 @@ packages:
     transitivePeerDependencies:
       - react
       - react-dom
+    dev: true
 
   /@types/wordpress__components@23.0.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-mpAVr74ElANYR6f8+atultx4A1Md40vZeKfA2ZtgcJMWXQWez3OzP1W2g20BENxOo2kWVsp1r3Tcik/mt/8l/g==}
@@ -3676,6 +3620,7 @@ packages:
     transitivePeerDependencies:
       - react
       - react-dom
+    dev: true
 
   /@types/wordpress__editor@13.6.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-3iiPWC8AjMGMMTImqCOkJiTbRmpfkjP8RljeL6cmtIVkrOrI5m5dizmq3hrtdB041rNTrPsItwRhchZO1EQVIw==}
@@ -3699,10 +3644,11 @@ packages:
       - supports-color
       - utf-8-validate
       - vite
-    dev: false
+    dev: true
 
   /@types/wordpress__keycodes@2.3.1:
     resolution: {integrity: sha512-CUZv3WdPvWqnEwojbc4yEttwZlvsMGI8YurgB9CHVJXx6nQ4U2RU6PB0Mv7nxATufduFDMKq8TNpCHBenZqEjQ==}
+    dev: true
 
   /@types/wordpress__media-utils@4.14.4(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-qAqvuljgN+bM+EWydj82+78qwoW3XgDtTrla6MW6uZ4Dj7aGgcmmwuNPtCghfLvBadCyC9jYOSBfASGJDXxeag==}
@@ -3713,7 +3659,7 @@ packages:
     transitivePeerDependencies:
       - react
       - react-dom
-    dev: false
+    dev: true
 
   /@types/wordpress__notices@3.27.0(react@18.2.0):
     resolution: {integrity: sha512-Da2iJ295TVYqk08EjgUuJjyxSV2DdBktrhBvNd38FH0jEFmI1Y4ollcMHvZ5EWlQk6rPeBreNke4PkuC9vL40A==}
@@ -3722,6 +3668,7 @@ packages:
       '@wordpress/data': 8.6.0(react@18.2.0)
     transitivePeerDependencies:
       - react
+    dev: true
 
   /@types/wordpress__rich-text@6.4.0(react@18.2.0):
     resolution: {integrity: sha512-xG+4ALsKVj4I6N7GXAvhxvobgri39rjiKBGRM1UTo02jFGVBQcE4ICSsggkZ/fox5WJwdk1vmWLFuQAGTNb7nw==}
@@ -3730,9 +3677,11 @@ packages:
       '@wordpress/data': 8.6.0(react@18.2.0)
     transitivePeerDependencies:
       - react
+    dev: true
 
   /@types/wordpress__shortcode@2.3.3:
     resolution: {integrity: sha512-I2e5phrpvqjDv1jtm6Fdo4CfQ6fnpssAJ3rdN//lqyw9TBWp1Ffi1g5xge5SD22d5WxUexbr+I6DFuVxF15IPg==}
+    dev: true
 
   /@types/ws@8.5.5:
     resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
@@ -3890,7 +3839,6 @@ packages:
 
   /@use-gesture/core@10.2.27:
     resolution: {integrity: sha512-V4XV7hn9GAD2MYu8yBBVi5iuWBsAMfjPRMsEVzoTNGYH72tf0kFP+OKqGKc8YJFQIJx6yj+AOqxmEHOmx2/MEA==}
-    dev: false
 
   /@use-gesture/react@10.2.27(react@18.2.0):
     resolution: {integrity: sha512-7E5vnWCxeslWlxwZ8uKIcnUZVMTRMZ8cvSnLLKF1NkyNb3PnNiAzoXM4G1vTKJKRhgOTeI6wK1YsEpwo9ABV5w==}
@@ -3899,7 +3847,6 @@ packages:
     dependencies:
       '@use-gesture/core': 10.2.27
       react: 18.2.0
-    dev: false
 
   /@webassemblyjs/ast@1.11.6:
     resolution: {integrity: sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==}
@@ -4055,7 +4002,6 @@ packages:
       '@babel/runtime': 7.22.5
       '@wordpress/dom-ready': 3.48.0
       '@wordpress/i18n': 4.48.0
-    dev: false
 
   /@wordpress/api-fetch@6.45.0:
     resolution: {integrity: sha512-87GhllJcdlxqLugQUx/hL+PE4z7Aqf+AFs8CgzN5/V7INq9IFlIjcbm5TpI4WrGVDSa2puA0tMrjhR/FWXF3NQ==}
@@ -4064,14 +4010,12 @@ packages:
       '@babel/runtime': 7.22.5
       '@wordpress/i18n': 4.48.0
       '@wordpress/url': 3.49.0
-    dev: false
 
   /@wordpress/autop@3.48.0:
     resolution: {integrity: sha512-vhcUVW/ZQC5UAeAQA9tkiwJDPEHF2gASCQp0G70Kt+wjUrXhS0mYt+gecWyRI6DwY3ZagYSdu5pAdV21iegBYg==}
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.22.5
-    dev: false
 
   /@wordpress/babel-plugin-import-jsx-pragma@4.19.0(@babel/core@7.22.5):
     resolution: {integrity: sha512-g2oMpFWL8AL+F9lZv2A2UDxsT5ai2qeIZ8STaFKV/9VbYRQSNmaunrf7CAJYbbWPZNRHucz7U7J1K7PzwSZ71w==}
@@ -4118,7 +4062,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.22.5
-    dev: false
 
   /@wordpress/block-editor@12.16.0(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-BfuRJbUCBFrOjGNMBgsz7pBxenu0Yr2aQQTtqR/++ezdyruXZneZTaxs7ZXaoQ5Jo5S/yHTrVP9UCDH0WW/Ycw==}
@@ -4184,14 +4127,12 @@ packages:
       - aslemammad-vite-plugin-macro
       - babel-plugin-macros
       - vite
-    dev: false
 
   /@wordpress/block-serialization-default-parser@4.48.0:
     resolution: {integrity: sha512-1wOIRn82Lfrz27M2GN1c1f1oJdDGUcsLzzFbDNdhV9iAQ3mEleMc8cbhGRQBagAdK1SVhH5ssAJ3I/E4RXLFNw==}
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.22.5
-    dev: false
 
   /@wordpress/blocks@11.21.0(react@18.2.0):
     resolution: {integrity: sha512-FlOrF0VMugW7wW9LAAF3ixUp2t1HsEGTBjqERYr7dYQIJI8yIII7/Zh2Opuzq0baWaA7kqexUQeD6sYSOcu8lA==}
@@ -4225,7 +4166,7 @@ packages:
       showdown: 1.9.1
       simple-html-tokenizer: 0.5.11
       uuid: 8.3.2
-    dev: false
+    dev: true
 
   /@wordpress/blocks@12.25.0(react@18.2.0):
     resolution: {integrity: sha512-We1iWq3Qhn/1g81/fwiydutC9z8PZdKckcxYQa2AFVZAgugJFAZ/yx2rsjIjwJVExaIi3Vr8nqLwRpzVoyzyzA==}
@@ -4261,7 +4202,6 @@ packages:
       showdown: 1.9.1
       simple-html-tokenizer: 0.5.11
       uuid: 9.0.1
-    dev: false
 
   /@wordpress/browserslist-config@5.19.0:
     resolution: {integrity: sha512-WBTpyVskyQjAIeBONjCHDIumyNfKldji5sd1+Y2gFBbAb4m8igr8OWWZj8iKqT+UkedHiZ6PkVw0+sg6kvk7bw==}
@@ -4295,7 +4235,6 @@ packages:
       - aslemammad-vite-plugin-macro
       - babel-plugin-macros
       - vite
-    dev: false
 
   /@wordpress/components@25.14.0(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-PwAhzLPIsNpO1Z/0hTO7hnC1gPQlhGkGey32kgcl0hnhgZqW/BsmWf+CdhlIY58fwrhv4vO3ixc6odEMIGlBaQ==}
@@ -4364,7 +4303,6 @@ packages:
       - aslemammad-vite-plugin-macro
       - babel-plugin-macros
       - vite
-    dev: false
 
   /@wordpress/components@25.3.0(@types/react-dom@18.2.6)(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-FriXiYSJSUvM+Cwvg2CGpgSheUH562voURqjWYdFMzUmKm/16eyr/qFzthQUWeTluDJ5wYMjR1hR8pYvSohmrA==}
@@ -4453,7 +4391,7 @@ packages:
       mousetrap: 1.6.5
       react: 18.2.0
       use-memo-one: 1.1.3(react@18.2.0)
-    dev: false
+    dev: true
 
   /@wordpress/compose@6.18.0(react@18.2.0):
     resolution: {integrity: sha512-aZyvttCnT8HI4vS8Nb8y5Go+AycrThy0gvEl9jc9ZB9emm1ZifNkA6gTNpBd7zU2uzS4wUpiZYGGvUNeAuShvQ==}
@@ -4495,7 +4433,6 @@ packages:
       mousetrap: 1.6.5
       react: 18.2.0
       use-memo-one: 1.1.3(react@18.2.0)
-    dev: false
 
   /@wordpress/core-data@5.5.0(react@18.2.0):
     resolution: {integrity: sha512-Nf7fhCyZOSl3156jGy0M2vHwQVT7Kp/NxMnDpdvCWIvJ7EzjoycSzbxpdjoG5UAQTNWiItdvRopzKJ/e9sA1Vg==}
@@ -4521,7 +4458,7 @@ packages:
       react: 18.2.0
       rememo: 4.0.2
       uuid: 8.3.2
-    dev: false
+    dev: true
 
   /@wordpress/core-data@6.25.0(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-JoInOwM41Np1sWWk79Eua8LYa2NQ+asW+bQbgHwstGU1n6iIVzhmnx+O5leGh1AKmcnQKxDPNADyaIOfxk8xow==}
@@ -4564,7 +4501,6 @@ packages:
       - supports-color
       - utf-8-validate
       - vite
-    dev: false
 
   /@wordpress/data@7.6.0(react@18.2.0):
     resolution: {integrity: sha512-Og+oinEpJzd2rI4cFQGJBtSNzSVEa1sDWje1dYc3Jm7t2/NpkGk/YXn0PlVhkakA7YCGBy2OhX122flgZBuaBw==}
@@ -4587,7 +4523,7 @@ packages:
       redux: 4.2.1
       turbo-combine-reducers: 1.0.2
       use-memo-one: 1.1.3(react@18.2.0)
-    dev: false
+    dev: true
 
   /@wordpress/data@8.6.0(react@18.2.0):
     resolution: {integrity: sha512-+bQ5dTkJkHeOng3mXXzLBZkudUlOifJql1U99sWGbtLarU/yjfF0ldi/a6uR1cVvDJkGizDYHf9vv/nA39Oaqw==}
@@ -4611,6 +4547,7 @@ packages:
       redux: 4.2.1
       turbo-combine-reducers: 1.0.2
       use-memo-one: 1.1.3(react@18.2.0)
+    dev: true
 
   /@wordpress/data@9.18.0(react@18.2.0):
     resolution: {integrity: sha512-ni+MehrwryItjpqDkPHtSSutkGTNkHhTnzQasZ9eHlME5a4SZugs6B6Lea7Gd+bbpocNEHFsP1dacluW72ov6A==}
@@ -4634,7 +4571,6 @@ packages:
       redux: 4.2.1
       rememo: 4.0.2
       use-memo-one: 1.1.3(react@18.2.0)
-    dev: false
 
   /@wordpress/data@9.7.0(react@18.2.0):
     resolution: {integrity: sha512-RBsgmAsG8ghR8U5zSlaAQYkovBMimAP+cnnjD1dwSq4ZPoHYXzzWPfHniVuOshK50x9pXt5ru0Zl6lvA2Es4CA==}
@@ -4678,7 +4614,6 @@ packages:
       '@wordpress/deprecated': 3.48.0
       moment: 2.29.4
       moment-timezone: 0.5.43
-    dev: false
 
   /@wordpress/dependency-extraction-webpack-plugin@4.19.0(webpack@5.88.1):
     resolution: {integrity: sha512-AxGi3XU7vMP0qfZOVKGXvh54uy02Y048St+b4JgvL7wfXBT0RuOrZjfMpcbDnzYW/1gHjyalkLb4zK12ml7E2A==}
@@ -4697,6 +4632,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       '@wordpress/hooks': 3.36.0
+    dev: true
 
   /@wordpress/deprecated@3.37.0:
     resolution: {integrity: sha512-lj5InuhaJGgg5jdceVL/8Raj0it4xdOO/TwlgbcJXhHFSIarUKqrg3JWA7Y427ibzJpq5ytGUYcSSbgVza7UlQ==}
@@ -4719,7 +4655,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       '@wordpress/hooks': 3.48.0
-    dev: false
 
   /@wordpress/dom-ready@3.37.0:
     resolution: {integrity: sha512-qA28n37BaSYIYLmfyiZAObKOfneUbkRXRpiZkcD8TQQNOa6e7utl9A1C3uS19jeR5Od3kANtjSYJpKshabnstg==}
@@ -4733,7 +4668,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.22.5
-    dev: false
 
   /@wordpress/dom@3.37.0:
     resolution: {integrity: sha512-KFPAzQYvKbF8J+RQmsdTE2h6iKsHD73eZvNN0dEs3FvUJtWATo3GwGrSYH1SeHd72xfHZR4d/Uw/aUcwlph2vA==}
@@ -4756,7 +4690,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       '@wordpress/deprecated': 3.48.0
-    dev: false
 
   /@wordpress/editor@13.25.0(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-1waT0ZG6ii98eOuqbOJMEE9vHp1Y8BGlnb37rwiFn61yeUnWuvH2qcHyPiRh4tUDYp3rHACa+P0joN4L32MeHA==}
@@ -4828,7 +4761,7 @@ packages:
       is-plain-object: 5.0.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-    dev: false
+    dev: true
 
   /@wordpress/element@5.13.0:
     resolution: {integrity: sha512-LG/JlqgcUf7v/lTkDQrqVFcD5k0kVEm2CfmzWznSy/DpupejMoyvoI0dJ8Y4AovMWKDXrgCVhk9jLpr9czVy3A==}
@@ -4842,6 +4775,7 @@ packages:
       is-plain-object: 5.0.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: true
 
   /@wordpress/element@5.14.0:
     resolution: {integrity: sha512-W2lBumRvJ3UvB1qZaWAp268xvirZEzFwyS/epLUPIPOnIW4u7UBfEmEbhPx55KSuTFHSR/hbiYSuWBdbVpd8tA==}
@@ -4882,13 +4816,13 @@ packages:
       is-plain-object: 5.0.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@wordpress/escape-html@2.36.0:
     resolution: {integrity: sha512-nrPBxOjo+4qVVMOdf0uCdo24Swi0lOLRuijq+ReeyUcCVg1Xxkqa6oFjYbcAaxWsUr1xPGwAR64oE4I/ZpluSA==}
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.22.5
+    dev: true
 
   /@wordpress/escape-html@2.37.0:
     resolution: {integrity: sha512-YJZAsZIWLx+RMs2TyxqqR1w7oXbedE/zrtBJh5/Gbt0UIP64/gQOgoRaEX3EhPOFd7lGWzWr/vH0tgLVGm2jJg==}
@@ -4908,7 +4842,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.22.5
-    dev: false
 
   /@wordpress/eslint-plugin@14.9.0(@babel/core@7.22.5)(eslint@8.43.0)(jest@29.5.0)(typescript@5.2.2)(wp-prettier@2.8.5):
     resolution: {integrity: sha512-Dz0cIpqNpaqla/bGGAwke2VH1YdJXMnPaqu1wPXAu3j4tJCEdjpy6+tAQqcmFHYfTGyobq4SnMJakC8gK/f5wg==}
@@ -4956,6 +4889,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.22.5
+    dev: true
 
   /@wordpress/hooks@3.37.0:
     resolution: {integrity: sha512-rJ1hJjXCSD/jOXoaKug75N9PCcg65diexSsyxzVHJCjT2je9J5hVJbHiyB+JfvvGCK5H6qii9M9rKKvESZwXqw==}
@@ -4975,7 +4909,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.22.5
-    dev: false
 
   /@wordpress/html-entities@3.37.0:
     resolution: {integrity: sha512-nou3D4+dDGrvD9whY0kdQr8gW7EFmD2HG1QudPXN3zJYDvW+LIR9TXlJhXghZ0550AjlmYCszY4xjPB2ZpaOsg==}
@@ -4989,7 +4922,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.22.5
-    dev: false
 
   /@wordpress/i18n@4.37.0:
     resolution: {integrity: sha512-bjq3C9DXAay4jEe1+Brl5Jt5hymf6LZfI8XuHYMw5ejFiQUUf3J/8DZZUpC+8xNOP8FAvO6W8BWOJISBJS+Ylw==}
@@ -5027,7 +4959,6 @@ packages:
       memize: 2.1.0
       sprintf-js: 1.1.2
       tannin: 1.2.0
-    dev: false
 
   /@wordpress/icons@9.28.0:
     resolution: {integrity: sha512-tmC1rYdcQEAuW2uLNi2JFgEsmzZR+/xZlWzYPcuqU3+t9tGsDhwzCUjgUErLNtTSH4TGV/3+Ti/mULVIAlealg==}
@@ -5045,13 +4976,13 @@ packages:
       '@babel/runtime': 7.22.5
       '@wordpress/element': 5.25.0
       '@wordpress/primitives': 3.46.0
-    dev: false
 
   /@wordpress/is-shallow-equal@4.36.0:
     resolution: {integrity: sha512-cKGuuw5ZaTEC6za630z1csoR+LxfssYtQ/L24iqiQqiIhw0Mwbxc7qNn+9PmmeCZ6PEPz7QDcbFztw0tvmY1JQ==}
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.22.5
+    dev: true
 
   /@wordpress/is-shallow-equal@4.37.0:
     resolution: {integrity: sha512-DRZYvrGiA0VatKMkUWyqz+ihS+Nf6rl5QaPlpOywpoe2Zmk3Ca3QnNQuVsjFc7VxnV9NtDImCIVRK+9NpcqAeA==}
@@ -5071,7 +5002,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.22.5
-    dev: false
 
   /@wordpress/jest-console@7.7.0(jest@29.5.0):
     resolution: {integrity: sha512-ZwGcuFRQv5XV1M1/BaUxZC/6iz38IzzW6rJc2DElxUnP3+Zvp5We/XWIeJBsIyBtCse+J1ruLnZovw2lv8hmnQ==}
@@ -5111,7 +5041,6 @@ packages:
       '@wordpress/keycodes': 3.48.0
       react: 18.2.0
       rememo: 4.0.2
-    dev: false
 
   /@wordpress/keycodes@3.37.0:
     resolution: {integrity: sha512-cbxoygTVPysy8pkyPgcnHfu7G0qD2QnKFffeVj/X2PCXA8KAAORrnErtpm+ULUagYjjfNb1J5ttj/cUf1Bgzvg==}
@@ -5136,7 +5065,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       '@wordpress/i18n': 4.48.0
-    dev: false
 
   /@wordpress/media-utils@4.39.0:
     resolution: {integrity: sha512-vJRqqnEIsAvgy82daf+qE87ncB4o8x2Y/1NbvqUJUvU/B+xDxRxZeOYdwcYIhb7VNFkWo+DMxtIuhiNX67XiTQ==}
@@ -5159,7 +5087,6 @@ packages:
       '@wordpress/a11y': 3.48.0
       '@wordpress/data': 9.18.0(react@18.2.0)
       react: 18.2.0
-    dev: false
 
   /@wordpress/npm-package-json-lint-config@4.21.0(npm-package-json-lint@5.4.2):
     resolution: {integrity: sha512-MycfWbm6HVJ6/mR/0GO9KLXN8ZGPTczgdAPXx1Vly3KFLtCsIoVEbSjDhNTaDX+j3FmzUoGWPISudMtZqAFN2w==}
@@ -5242,7 +5169,6 @@ packages:
       - aslemammad-vite-plugin-macro
       - babel-plugin-macros
       - vite
-    dev: false
 
   /@wordpress/prettier-config@2.19.0(wp-prettier@2.8.5):
     resolution: {integrity: sha512-9vs+ShgVu4NleSg89v/g6qtA3gLcaInRklKquerjVXtzRcYlC1vIP1MMi3CD6WAg5f1AU+xlHd4EsIL/Aq9qng==}
@@ -5269,7 +5195,6 @@ packages:
       '@babel/runtime': 7.22.5
       '@wordpress/element': 5.25.0
       classnames: 2.3.2
-    dev: false
 
   /@wordpress/priority-queue@2.36.0:
     resolution: {integrity: sha512-CjEHD5VL+C5je5F+ZmYmE6dStpjFVykDqgelHsJemAo263r5uhMsr4HDcDbEaiXtJh89UrFVW3B2ZD/+X+VRgA==}
@@ -5277,6 +5202,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       requestidlecallback: 0.3.0
+    dev: true
 
   /@wordpress/priority-queue@2.37.0:
     resolution: {integrity: sha512-3aIAjFlgyASVrRxe36ep3vX3cahmdBEL7nFWsCQPrPudh3c0jAjITW+f5IQ1xmmwnFZfiUbggPxtS1f3FQOcXg==}
@@ -5299,13 +5225,13 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       requestidlecallback: 0.3.0
-    dev: false
 
   /@wordpress/private-apis@0.11.0:
     resolution: {integrity: sha512-GpAZ34Ou9YkYi9fuJCb9oDIZhsLqj41stuHflxpTNih6vV/Qw7ApBkLZDhDCyWjOybnjtHQH1LWw3K3RCN4miw==}
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.22.5
+    dev: true
 
   /@wordpress/private-apis@0.19.0:
     resolution: {integrity: sha512-oObjdfSbvYrbicwLEBSrZQF6KOe9CUfWXJsZqqmkpbkOmGMb2NfdzHa1oJ0UcGwAHelBxHpmIt0C7jzUzUJ0sQ==}
@@ -5319,7 +5245,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.22.5
-    dev: false
 
   /@wordpress/redux-routine@4.36.0(redux@4.2.1):
     resolution: {integrity: sha512-l2sqm6v5JasNMRgzRvJkOfDV9CNKBB3dXjcLrRCVHMbbealIPY3MRcaMU9KtoGLAeSio0oXMuQCdABYc0nQ8lg==}
@@ -5332,6 +5257,7 @@ packages:
       is-promise: 4.0.0
       redux: 4.2.1
       rungen: 0.3.2
+    dev: true
 
   /@wordpress/redux-routine@4.37.0(redux@4.2.1):
     resolution: {integrity: sha512-VS/MYhIGHs3/5eXG1wsFGWoSJNVKrlug0RZtUMox3UhkJShT0LkfOaaLNdwBdTGQwciZRT0TxsiQ7UerZJIHrg==}
@@ -5357,7 +5283,6 @@ packages:
       is-promise: 4.0.0
       redux: 4.2.1
       rungen: 0.3.2
-    dev: false
 
   /@wordpress/reusable-blocks@4.25.0(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-R7ysUJMRcxfGeF0Ly7/5QK7L32aHsGHXamSQY5h+aBhdNhKRtElWZKvzaKiw7AmKUqWpCQtpa8elFm2Iim//vw==}
@@ -5430,7 +5355,6 @@ packages:
       memize: 2.1.0
       react: 18.2.0
       rememo: 4.0.2
-    dev: false
 
   /@wordpress/scripts@26.6.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2):
     resolution: {integrity: sha512-Pcyg9fg1UL5S0V0iUhZTutqml19nARR99A/LR8gYr3YVzVT5qTV2eyvzZRgs5lTcnBaOfUfKBucWi69v5+yEVg==}
@@ -5562,7 +5486,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       memize: 2.1.0
-    dev: false
 
   /@wordpress/style-engine@1.31.0:
     resolution: {integrity: sha512-/mm8u5g5j12qFhER6g/aFoe804mURVgvheJyNYaFbLxmheGT+Csx1Mk5itwPsZIXk2yFjNEbDnX1fBStnvVT0g==}
@@ -5570,7 +5493,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       change-case: 4.1.2
-    dev: false
 
   /@wordpress/stylelint-config@21.19.0(postcss@8.4.24)(stylelint@14.16.1):
     resolution: {integrity: sha512-An5wuXXtvbNniyoXahs265owgPepfoeG3Mp8/WMf6nuRg89Hjn8UFd5Dtl6NrrVI/TvlbDU+IN9WYrjBDTY3fA==}
@@ -5603,14 +5525,12 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
-    dev: false
 
   /@wordpress/token-list@2.48.0:
     resolution: {integrity: sha512-6/DBs+ZEREMn6buuIVrNHwOE7BFeohWVJGoF7ul2BvrWEmnbsI7Xzcjuir9+M22N4bdTbQCc4ndnrRal7EgCRg==}
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.22.5
-    dev: false
 
   /@wordpress/undo-manager@0.8.0:
     resolution: {integrity: sha512-960Vvr8I78nCp2r2u0Ia9JTUiTTwR43kbLHrFztqqpRH5WIIBgqH5KOOlylT9jLhozYOuOTz9vmN5NMfZKmyAg==}
@@ -5618,7 +5538,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       '@wordpress/is-shallow-equal': 4.48.0
-    dev: false
 
   /@wordpress/url@3.42.0:
     resolution: {integrity: sha512-Q1eZAkgnq/Ji3UDdBPxj2mBiBusGoTkcUH2XnJDGyPIezJjC7fY/9GXE6Jj0bm37CkEH3bP6G4Yrh+YpDwMn6Q==}
@@ -5634,7 +5553,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       remove-accents: 0.5.0
-    dev: false
 
   /@wordpress/warning@2.36.0:
     resolution: {integrity: sha512-v78f8PuWSHvtik1b1GklpPuNnouVxl8WaRs7CfixR6D8tZQ3Y4zlMj6fFZtxvQefDvbKwQxIOwcK/50AsFp6ww==}
@@ -5649,14 +5567,12 @@ packages:
   /@wordpress/warning@2.48.0:
     resolution: {integrity: sha512-M8KB8OdxHHxLDPy/1DuSi4SKYrR4/LL2jLWS9GkTa0eSe7PKxIscXH3Q0giFwcREkz80J0rFuADCInCuyIr5Kg==}
     engines: {node: '>=12'}
-    dev: false
 
   /@wordpress/wordcount@3.48.0:
     resolution: {integrity: sha512-AophIntlbTSpzsxHsfnN6Ajxu9aQ7qiFuXmMZwv7f/IcB/tEAGQ7WPNdABeWY8EalDPWGXQeLFTLJkj0wy/jrA==}
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.22.5
-    dev: false
 
   /@xtuc/ieee754@1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -5796,7 +5712,6 @@ packages:
   /ansi-regex@4.1.1:
     resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
     engines: {node: '>=6'}
-    dev: false
 
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -5844,7 +5759,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       tslib: 2.6.0
-    dev: false
 
   /aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
@@ -6059,7 +5973,6 @@ packages:
       '@babel/runtime': 7.22.5
       cosmiconfig: 7.1.0
       resolve: 1.22.2
-    dev: false
 
   /babel-plugin-polyfill-corejs2@0.4.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-bM3gHc337Dta490gg+/AseNB9L4YLHxq1nGKZZSHbhXv4aTYU2MD2cjza1Ru4S6975YLTaL1K8uJf6ukJhhmtw==}
@@ -6182,7 +6095,6 @@ packages:
 
   /body-scroll-lock@3.1.5:
     resolution: {integrity: sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg==}
-    dev: false
 
   /bonjour-service@1.1.1:
     resolution: {integrity: sha512-Z/5lQRMOG9k7W+FkeGTNjh7htqn/2LMnfOvBZ8pynNZCM9MwkQkI3zeI4oz09uWdcgmgHugVvBqxGg4VQJ5PCg==}
@@ -6248,7 +6160,6 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-    dev: false
 
   /bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
@@ -6408,7 +6319,6 @@ packages:
 
   /classnames@2.3.2:
     resolution: {integrity: sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==}
-    dev: false
 
   /clean-webpack-plugin@3.0.0(webpack@5.88.1):
     resolution: {integrity: sha512-MciirUH5r+cYLGCOL5JX/ZLzOZbVr1ot3Fw+KcvbhUb6PM+yycqd9ZhIlcigQ5gl+XhppNmw3bEFuaaMNyLj3A==}
@@ -6434,7 +6344,6 @@ packages:
       string-width: 3.1.0
       strip-ansi: 5.2.0
       wrap-ansi: 5.1.0
-    dev: false
 
   /cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -6477,7 +6386,6 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
-    dev: false
 
   /co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -6523,7 +6431,6 @@ packages:
 
   /command-score@0.1.2:
     resolution: {integrity: sha512-VtDvQpIJBvBatnONUsPzXYFVKQQAhuf3XTNOAsdBxCNO/QCtUUd8LSgjn0GVarBkCad6aJCZfXgrjYbl/KRr7w==}
-    dev: false
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -6869,7 +6776,6 @@ packages:
     engines: {node: '>=0.11'}
     dependencies:
       '@babel/runtime': 7.22.5
-    dev: false
 
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -7005,7 +6911,6 @@ packages:
 
   /detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
-    dev: false
 
   /detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
@@ -7023,7 +6928,6 @@ packages:
   /diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
-    dev: false
 
   /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -7059,7 +6963,6 @@ packages:
 
   /dom-scroll-into-view@1.2.1:
     resolution: {integrity: sha512-LwNVg3GJOprWDO+QhLL1Z9MMgWe/KAFLxVWKzjRTxNSPn8/LLDIfmuG71YHznXCqaqTjvHJDYO1MEAgX6XCNbQ==}
-    dev: false
 
   /dom-serializer@1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
@@ -7132,7 +7035,6 @@ packages:
 
   /emoji-regex@7.0.3:
     resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==}
-    dev: false
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -7195,7 +7097,6 @@ packages:
 
   /err-code@3.0.1:
     resolution: {integrity: sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==}
-    dev: false
 
   /error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -7873,14 +7774,12 @@ packages:
 
   /find-root@1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
-    dev: false
 
   /find-up@3.0.0:
     resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
     engines: {node: '>=6'}
     dependencies:
       locate-path: 3.0.0
-    dev: false
 
   /find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -7995,7 +7894,6 @@ packages:
       tslib: 2.6.0
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
-    dev: false
 
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -8051,7 +7949,6 @@ packages:
 
   /get-browser-rtc@1.1.0:
     resolution: {integrity: sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ==}
-    dev: false
 
   /get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -8069,7 +7966,6 @@ packages:
   /get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
-    dev: false
 
   /get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
@@ -8246,7 +8142,6 @@ packages:
   /gradient-parser@0.1.5:
     resolution: {integrity: sha512-+uPlcVbjrKOnTzvz0MjTj7BfACj8OmxIa1moIjJV7btvhUMSJk0D47RfDCgDrZE3dYMz9Cf5xKJwnrKLjUq0KQ==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /grapheme-splitter@1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
@@ -8322,13 +8217,11 @@ packages:
 
   /highlight-words-core@1.2.2:
     resolution: {integrity: sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==}
-    dev: false
 
   /hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
       react-is: 16.13.1
-    dev: false
 
   /homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
@@ -8359,7 +8252,6 @@ packages:
 
   /hpq@1.4.0:
     resolution: {integrity: sha512-ycJQMRaRPBcfnoT1gS5I1XCvbbw9KO94Y0vkwksuOjcJMqNZtb03MF2tCItLI2mQbkZWSSeFinoRDPmjzv4tKg==}
-    dev: false
 
   /html-encoding-sniffer@3.0.0:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
@@ -8534,7 +8426,6 @@ packages:
 
   /import-locals@2.0.0:
     resolution: {integrity: sha512-1/bPE89IZhyf7dr5Pkz7b4UyVXy5pEt7PTEfye15UEn3AK8+2zwcDCfKk9Pwun4ltfhOSszOrReSsFcDKw/yoA==}
-    dev: false
 
   /imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -8587,7 +8478,6 @@ packages:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
     dependencies:
       loose-envify: 1.4.0
-    dev: false
 
   /ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -8676,7 +8566,6 @@ packages:
   /is-fullwidth-code-point@2.0.0:
     resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==}
     engines: {node: '>=4'}
-    dev: false
 
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -8846,7 +8735,6 @@ packages:
 
   /isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
-    dev: false
 
   /istanbul-lib-coverage@3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
@@ -9564,7 +9452,6 @@ packages:
     hasBin: true
     dependencies:
       isomorphic.js: 0.2.5
-    dev: false
 
   /lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
@@ -9606,7 +9493,6 @@ packages:
     dependencies:
       p-locate: 3.0.0
       path-exists: 3.0.0
-    dev: false
 
   /locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -9644,6 +9530,7 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
 
   /log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -9776,7 +9663,7 @@ packages:
 
   /memize@1.1.0:
     resolution: {integrity: sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==}
-    dev: false
+    dev: true
 
   /memize@2.1.0:
     resolution: {integrity: sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg==}
@@ -9934,11 +9821,9 @@ packages:
     resolution: {integrity: sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==}
     dependencies:
       moment: 2.29.4
-    dev: false
 
   /moment@2.29.4:
     resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
-    dev: false
 
   /mousetrap@1.6.5:
     resolution: {integrity: sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==}
@@ -10056,7 +9941,6 @@ packages:
 
   /normalize-wheel@1.0.1:
     resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
-    dev: false
 
   /npm-bundled@1.1.2:
     resolution: {integrity: sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==}
@@ -10259,7 +10143,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       p-limit: 2.3.0
-    dev: false
 
   /p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
@@ -10344,7 +10227,6 @@ packages:
   /path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
     engines: {node: '>=4'}
-    dev: false
 
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -10374,7 +10256,6 @@ packages:
 
   /path-to-regexp@6.2.1:
     resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
-    dev: false
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -10738,7 +10619,6 @@ packages:
       postcss: '*'
     dependencies:
       postcss: 8.4.24
-    dev: false
 
   /postcss-reduce-initial@5.1.2(postcss@8.4.24):
     resolution: {integrity: sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==}
@@ -10819,7 +10699,6 @@ packages:
     dependencies:
       postcss: 8.4.24
       postcss-value-parser: 4.2.0
-    dev: false
 
   /postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -10887,7 +10766,6 @@ packages:
 
   /proxy-compare@2.3.0:
     resolution: {integrity: sha512-c3L2CcAi7f7pvlD0D7xsF+2CQIW8C3HaYx2Pfgq8eA4HAl3GAH6/dVYsyBbYF/0XJs2ziGLrzmz5fmzPm6A0pQ==}
-    dev: false
 
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
@@ -11008,7 +10886,6 @@ packages:
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /react-dom@17.0.2(react@17.0.2):
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
@@ -11019,7 +10896,7 @@ packages:
       object-assign: 4.1.1
       react: 17.0.2
       scheduler: 0.20.2
-    dev: false
+    dev: true
 
   /react-dom@18.2.0(react@18.2.0):
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
@@ -11040,7 +10917,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.0.1
-    dev: false
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -11071,7 +10947,6 @@ packages:
       react: 18.2.0
       react-style-singleton: 2.2.1(@types/react@18.2.14)(react@18.2.0)
       tslib: 2.6.0
-    dev: false
 
   /react-remove-scroll@2.5.4(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-xGVKJJr0SJGQVirVFAUZ2k1QLyO6m+2fy0l8Qawbp5Jgrv3DeLalrfMNBFSlmz5kriGGzsVBtGVnf4pTKIhhWA==}
@@ -11090,7 +10965,6 @@ packages:
       tslib: 2.6.0
       use-callback-ref: 1.3.0(@types/react@18.2.14)(react@18.2.0)
       use-sidecar: 1.1.2(@types/react@18.2.14)(react@18.2.0)
-    dev: false
 
   /react-remove-scroll@2.5.5(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==}
@@ -11109,7 +10983,6 @@ packages:
       tslib: 2.6.0
       use-callback-ref: 1.3.0(@types/react@18.2.14)(react@18.2.0)
       use-sidecar: 1.1.2(@types/react@18.2.14)(react@18.2.0)
-    dev: false
 
   /react-style-singleton@2.2.1(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
@@ -11126,7 +10999,6 @@ packages:
       invariant: 2.2.4
       react: 18.2.0
       tslib: 2.6.0
-    dev: false
 
   /react@17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
@@ -11134,7 +11006,7 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-    dev: false
+    dev: true
 
   /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
@@ -11197,7 +11069,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       reakit-utils: 0.15.2(react-dom@18.2.0)(react@18.2.0)
-    dev: false
 
   /reakit-utils@0.15.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==}
@@ -11207,7 +11078,6 @@ packages:
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /reakit-warning@0.6.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-z/3fvuc46DJyD3nJAUOto6inz2EbSQTjvI/KBQDqxwB0y02HDyeP8IWOJxvkuAUGkWpeSx+H3QWQFSNiPcHtmw==}
@@ -11218,7 +11088,6 @@ packages:
       reakit-utils: 0.15.2(react-dom@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - react-dom
-    dev: false
 
   /reakit@1.3.11(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-mYxw2z0fsJNOQKAEn5FJCPTU3rcrY33YZ/HzoWqZX0G7FwySp1wkCYW79WhuYMNIUFQ8s3Baob1RtsEywmZSig==}
@@ -11233,7 +11102,6 @@ packages:
       reakit-system: 0.15.2(react-dom@18.2.0)(react@18.2.0)
       reakit-utils: 0.15.2(react-dom@18.2.0)(react@18.2.0)
       reakit-warning: 0.6.2(react-dom@18.2.0)(react@18.2.0)
-    dev: false
 
   /rechoir@0.7.1:
     resolution: {integrity: sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==}
@@ -11305,15 +11173,12 @@ packages:
 
   /rememo@4.0.2:
     resolution: {integrity: sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==}
-    dev: false
 
   /remove-accents@0.4.4:
     resolution: {integrity: sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==}
-    dev: false
 
   /remove-accents@0.5.0:
     resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
-    dev: false
 
   /requestidlecallback@0.3.0:
     resolution: {integrity: sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==}
@@ -11329,7 +11194,6 @@ packages:
 
   /require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
-    dev: false
 
   /requireindex@1.2.0:
     resolution: {integrity: sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==}
@@ -11506,7 +11370,7 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-    dev: false
+    dev: true
 
   /scheduler@0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
@@ -11636,7 +11500,6 @@ packages:
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
-    dev: false
 
   /setprototypeof@1.1.0:
     resolution: {integrity: sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==}
@@ -11696,7 +11559,6 @@ packages:
     hasBin: true
     dependencies:
       yargs: 14.2.3
-    dev: false
 
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
@@ -11712,7 +11574,6 @@ packages:
 
   /simple-html-tokenizer@0.5.11:
     resolution: {integrity: sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==}
-    dev: false
 
   /simple-peer@9.11.1:
     resolution: {integrity: sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw==}
@@ -11726,7 +11587,6 @@ packages:
       readable-stream: 3.6.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /sirv@1.0.19:
     resolution: {integrity: sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==}
@@ -11807,7 +11667,6 @@ packages:
   /source-map@0.5.7:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -11923,7 +11782,6 @@ packages:
       emoji-regex: 7.0.3
       is-fullwidth-code-point: 2.0.0
       strip-ansi: 5.2.0
-    dev: false
 
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -11988,7 +11846,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       ansi-regex: 4.1.1
-    dev: false
 
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -12128,7 +11985,6 @@ packages:
 
   /stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
-    dev: false
 
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -12366,7 +12222,6 @@ packages:
 
   /tslib@2.0.1:
     resolution: {integrity: sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==}
-    dev: false
 
   /tslib@2.6.0:
     resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==}
@@ -12564,7 +12419,6 @@ packages:
       '@types/react': 18.2.14
       react: 18.2.0
       tslib: 2.6.0
-    dev: false
 
   /use-isomorphic-layout-effect@1.1.2(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
@@ -12577,7 +12431,6 @@ packages:
     dependencies:
       '@types/react': 18.2.14
       react: 18.2.0
-    dev: false
 
   /use-lilius@2.0.3(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-+Q7nspdv+QGnyHGVMd6yAdLrqv5EGB4n3ix4GJH0JEE27weKCLCLmZSuAr5Nw+yPBCZn/iZ+KjL5+UykLCWXrw==}
@@ -12588,7 +12441,6 @@ packages:
       date-fns: 2.30.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /use-memo-one@1.1.3(react@18.2.0):
     resolution: {integrity: sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==}
@@ -12611,7 +12463,6 @@ packages:
       detect-node-es: 1.1.0
       react: 18.2.0
       tslib: 2.6.0
-    dev: false
 
   /use-sync-external-store@1.2.0(react@18.2.0):
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
@@ -12619,7 +12470,6 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.2.0
-    dev: false
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -12636,7 +12486,6 @@ packages:
   /uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
-    dev: false
 
   /v8-compile-cache@2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
@@ -12685,7 +12534,6 @@ packages:
       proxy-compare: 2.3.0
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
-    dev: false
 
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -12972,7 +12820,6 @@ packages:
 
   /which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
-    dev: false
 
   /which-typed-array@1.1.9:
     resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}
@@ -13018,7 +12865,6 @@ packages:
       ansi-styles: 3.2.1
       string-width: 3.1.0
       strip-ansi: 5.2.0
-    dev: false
 
   /wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -13079,7 +12925,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-    dev: false
     optional: true
 
   /ws@8.5.0:
@@ -13112,7 +12957,6 @@ packages:
     dependencies:
       lib0: 0.2.88
       yjs: 13.6.10
-    dev: false
 
   /y-protocols@1.0.6(yjs@13.6.10):
     resolution: {integrity: sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==}
@@ -13122,7 +12966,6 @@ packages:
     dependencies:
       lib0: 0.2.88
       yjs: 13.6.10
-    dev: false
 
   /y-webrtc@10.2.6(yjs@13.6.10):
     resolution: {integrity: sha512-1kZ4YYwksFZi8+l8mTebVX9vW6Q5MnqxMkvNU700X5dBE38usurt/JgeXSIQRpK3NwUYYb9y63Jn9FMpMH6/vA==}
@@ -13141,11 +12984,9 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
-    dev: false
 
   /y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
-    dev: false
 
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -13173,7 +13014,6 @@ packages:
     dependencies:
       camelcase: 5.3.1
       decamelize: 1.2.0
-    dev: false
 
   /yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
@@ -13207,7 +13047,6 @@ packages:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 15.0.3
-    dev: false
 
   /yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -13234,7 +13073,6 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     dependencies:
       lib0: 0.2.88
-    dev: false
 
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}

--- a/src/button/get-classes.ts
+++ b/src/button/get-classes.ts
@@ -1,4 +1,3 @@
-//@ts-ignore
 import { isUndefined, trim, isEmpty } from "lodash";
 import { ButtonBlockTypes } from "./type";
 

--- a/src/button/get-styles.ts
+++ b/src/button/get-styles.ts
@@ -1,4 +1,3 @@
-//@ts-ignore
 import { omitBy, isUndefined, trim, isEmpty, isNumber } from "lodash";
 import { ButtonBlockTypes } from "./type";
 

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -25,7 +25,6 @@ import {
     RichText,
     useBlockProps,
     InspectorControls,
-    // @ts-ignore
     __experimentalUseBorderProps as useBorderProps,
     // @ts-ignore
     __experimentalLinkControl as LinkControl,

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -21,7 +21,6 @@ import {
 
 import metadata from "./block.json";
 import {
-    // @ts-ignore
     AlignmentControl,
     RichText,
     useBlockProps,

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -210,7 +210,7 @@ function edit({
                     style={{ ...borderProps.style }}
                 />
             </div>
-            {/* @ts-ignore */}
+
             <BlockControls group="block">
                 <BlockAlignmentToolbar
                     value={align}
@@ -265,7 +265,7 @@ function edit({
                     </Popover>
                 )}
             </BlockControls>
-            {/* @ts-ignore */}
+
             <InspectorControls group="color">
                 <ColorSettings
                     attrKey="textColor"
@@ -292,7 +292,7 @@ function edit({
                     setAttributes={setAttributes}
                 />
             </InspectorControls>
-            {/* @ts-ignore */}
+
             <InspectorControls group="advanced">
                 <TextControl
                     label="HTML ID"

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -202,7 +202,6 @@ function edit({
                             text: value.replace(/<\/?a[^>]*>/g, ""),
                         })
                     }
-                    // @ts-ignore
                     withoutInteractiveFormatting
                     identifier="text"
                     style={{ ...borderProps.style }}

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -5,9 +5,7 @@ import {
     BlockSaveProps,
     registerBlockType,
 } from "@wordpress/blocks";
-// @ts-ignore
 import { prependHTTP } from "@wordpress/url";
-// @ts-ignore
 import { useMergeRefs } from "@wordpress/compose";
 
 import {

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -26,7 +26,6 @@ import {
     useBlockProps,
     InspectorControls,
     __experimentalUseBorderProps as useBorderProps,
-    // @ts-ignore
     __experimentalLinkControl as LinkControl,
     BlockControls,
     BlockAlignmentToolbar,
@@ -109,7 +108,7 @@ function edit({
         setAttributes({ align: newValue });
     };
 
-    const onToggleOpenInNewTab = (value: boolean) => {
+    const onToggleOpenInNewTab = (value: boolean | undefined) => {
         const newLinkTarget = value ? "_blank" : undefined;
 
         if (newLinkTarget && !rel) {
@@ -241,9 +240,6 @@ function edit({
                             onChange={({
                                 url: newURL = "",
                                 opensInNewTab: newOpensInNewTab,
-                            }: {
-                                url: string;
-                                opensInNewTab: boolean;
                             }) => {
                                 setAttributes({ url: prependHTTP(newURL) });
 

--- a/src/cell/index.tsx
+++ b/src/cell/index.tsx
@@ -1,7 +1,6 @@
 import {
     BlockEditProps,
     registerBlockType,
-    //@ts-ignore
     createBlocksFromInnerBlocksTemplate,
     createBlock,
     BlockInstance,

--- a/src/components/border-control/index.tsx
+++ b/src/components/border-control/index.tsx
@@ -1,7 +1,6 @@
 /**
  * WordPress Dependencies
  */
-//@ts-ignore
 import { isEmpty } from "lodash";
 import { __ } from "@wordpress/i18n";
 import {

--- a/src/components/border-control/index.tsx
+++ b/src/components/border-control/index.tsx
@@ -4,9 +4,7 @@
 import { isEmpty } from "lodash";
 import { __ } from "@wordpress/i18n";
 import {
-    // @ts-ignore
     useBlockEditContext,
-    // @ts-ignore
     __experimentalBorderRadiusControl as BorderRadiusControl,
     store as BlockEditorStore,
 } from "@wordpress/block-editor";
@@ -51,7 +49,7 @@ function BorderControl({
                 select(BlockEditorStore) as BlockEditorStoreSelectors
             ).getSelectedBlock()?.attributes,
         []
-    );
+    )!;
     const { updateBlockAttributes } = useDispatch(
         BlockEditorStore
     ) as BlockEditorStoreActions;

--- a/src/components/border-control/index.tsx
+++ b/src/components/border-control/index.tsx
@@ -8,6 +8,7 @@ import {
     useBlockEditContext,
     // @ts-ignore
     __experimentalBorderRadiusControl as BorderRadiusControl,
+    store as BlockEditorStore,
 } from "@wordpress/block-editor";
 import { useSelect, useDispatch } from "@wordpress/data";
 import {
@@ -17,6 +18,10 @@ import {
 } from "@wordpress/components";
 
 import type { BorderControlPropTypes } from "../types";
+import {
+    BlockEditorStoreActions,
+    BlockEditorStoreSelectors,
+} from "../../wordpress__data";
 
 export function splitBorderRadius(value: string | object) {
     const isValueMixed = typeof value === "string";
@@ -40,24 +45,27 @@ function BorderControl({
     showDefaultBorderRadius = false,
 }: BorderControlPropTypes) {
     const { clientId } = useBlockEditContext();
-    // @ts-ignore
     const attributes = useSelect(
-        // @ts-ignore
-        (select) => select("core/block-editor").getSelectedBlock().attributes
+        (select) =>
+            (
+                select(BlockEditorStore) as BlockEditorStoreSelectors
+            ).getSelectedBlock()?.attributes,
+        []
     );
-    const { updateBlockAttributes } = useDispatch("core/block-editor");
+    const { updateBlockAttributes } = useDispatch(
+        BlockEditorStore
+    ) as BlockEditorStoreActions;
     const setAttributes = (newAttributes: object) => {
         updateBlockAttributes(clientId, newAttributes);
     };
-    // @ts-ignore
+
     const { defaultColors } = useSelect((select) => {
         return {
-            defaultColors:
-                // @ts-ignore
-                select("core/block-editor")?.getSettings()
-                    ?.__experimentalFeatures?.color?.palette?.default,
+            defaultColors: (
+                select(BlockEditorStore) as BlockEditorStoreSelectors
+            ).getSettings()?.__experimentalFeatures?.color?.palette?.default,
         };
-    });
+    }, []);
     return (
         <>
             {showBorder && (

--- a/src/components/color-settings/color-settings-with-gradient.tsx
+++ b/src/components/color-settings/color-settings-with-gradient.tsx
@@ -40,8 +40,7 @@ function ColorSettingWithGradient({
             select(blockEditorStore) as BlockEditorStoreSelectors
         ).getBlockAttributes(clientId);
     }, []);
-    // @ts-ignore
-    const setAttributes = (newAttributes) =>
+    const setAttributes = (newAttributes: Record<string, any>) =>
         updateBlockAttributes(clientId, newAttributes);
     const colorGradientSettings = useMultipleOriginColorsAndGradients();
     console.log(colorGradientSettings);

--- a/src/components/color-settings/color-settings-with-gradient.tsx
+++ b/src/components/color-settings/color-settings-with-gradient.tsx
@@ -5,11 +5,9 @@
 import { useDispatch, useSelect } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
 import {
-    // @ts-ignore
     useBlockEditContext,
     // @ts-ignore
     __experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
-    // @ts-ignore
     __experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
     store as blockEditorStore,
 } from "@wordpress/block-editor";
@@ -46,6 +44,7 @@ function ColorSettingWithGradient({
     const setAttributes = (newAttributes) =>
         updateBlockAttributes(clientId, newAttributes);
     const colorGradientSettings = useMultipleOriginColorsAndGradients();
+    console.log(colorGradientSettings);
 
     const { defaultColors, defaultGradients } = useSelect((select) => {
         return {

--- a/src/components/color-settings/color-settings-with-gradient.tsx
+++ b/src/components/color-settings/color-settings-with-gradient.tsx
@@ -11,8 +11,13 @@ import {
     __experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
     // @ts-ignore
     __experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
+    store as blockEditorStore,
 } from "@wordpress/block-editor";
 import { ColorSettingsWithGradientPropTypes } from "../types";
+import {
+    BlockEditorStoreActions,
+    BlockEditorStoreSelectors,
+} from "../../wordpress__data";
 
 /**
  *
@@ -28,31 +33,31 @@ function ColorSettingWithGradient({
     label,
 }: ColorSettingsWithGradientPropTypes) {
     const { clientId } = useBlockEditContext();
-    const { updateBlockAttributes } = useDispatch("core/block-editor");
+    const { updateBlockAttributes } = useDispatch(
+        blockEditorStore
+    ) as BlockEditorStoreActions;
 
-    // @ts-ignore
     const attributes = useSelect((select) => {
-        // @ts-ignore
-        return select("core/block-editor").getBlockAttributes(clientId);
-    });
+        return (
+            select(blockEditorStore) as BlockEditorStoreSelectors
+        ).getBlockAttributes(clientId);
+    }, []);
     // @ts-ignore
     const setAttributes = (newAttributes) =>
         updateBlockAttributes(clientId, newAttributes);
     const colorGradientSettings = useMultipleOriginColorsAndGradients();
-    // @ts-ignore
+
     const { defaultColors, defaultGradients } = useSelect((select) => {
         return {
-            defaultColors:
-                // @ts-ignore
-                select("core/block-editor")?.getSettings()
-                    ?.__experimentalFeatures?.color?.palette?.default,
+            defaultColors: (
+                select(blockEditorStore) as BlockEditorStoreSelectors
+            ).getSettings()?.__experimentalFeatures?.color?.palette?.default,
 
-            defaultGradients:
-                // @ts-ignore
-                select("core/block-editor")?.getSettings()
-                    ?.__experimentalFeatures?.color?.gradients?.default,
+            defaultGradients: (
+                select(blockEditorStore) as BlockEditorStoreSelectors
+            ).getSettings()?.__experimentalFeatures?.color?.gradients?.default,
         };
-    });
+    }, []);
 
     return (
         <ColorGradientSettingsDropdown

--- a/src/components/color-settings/color-settings.tsx
+++ b/src/components/color-settings/color-settings.tsx
@@ -11,8 +11,13 @@ import {
     __experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
     // @ts-ignore
     __experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
+    store as blockEditorStore,
 } from "@wordpress/block-editor";
 import { ColorSettingsPropTypes } from "../types";
+import {
+    BlockEditorStoreActions,
+    BlockEditorStoreSelectors,
+} from "../../wordpress__data";
 
 /**
  *
@@ -23,26 +28,27 @@ import { ColorSettingsPropTypes } from "../types";
  */
 function ColorSetting({ attrKey, label }: ColorSettingsPropTypes) {
     const { clientId } = useBlockEditContext();
-    const { updateBlockAttributes } = useDispatch("core/block-editor");
+    const { updateBlockAttributes } = useDispatch(
+        blockEditorStore
+    ) as BlockEditorStoreActions;
 
-    // @ts-ignore
     const attributes = useSelect((select) => {
-        // @ts-ignore
-        return select("core/block-editor").getBlockAttributes(clientId);
-    });
+        return (
+            select(blockEditorStore) as BlockEditorStoreSelectors
+        ).getBlockAttributes(clientId);
+    }, []);
 
     const setAttributes = (newAttributes: object) =>
         updateBlockAttributes(clientId, newAttributes);
     const colorGradientSettings = useMultipleOriginColorsAndGradients();
-    // @ts-ignore
+
     const { defaultColors } = useSelect((select) => {
         return {
-            defaultColors:
-                // @ts-ignore
-                select("core/block-editor")?.getSettings()
-                    ?.__experimentalFeatures?.color?.palette?.default,
+            defaultColors: (
+                select(blockEditorStore) as BlockEditorStoreSelectors
+            ).getSettings()?.__experimentalFeatures?.color?.palette?.default,
         };
-    });
+    }, []);
 
     return (
         <ColorGradientSettingsDropdown

--- a/src/components/color-settings/color-settings.tsx
+++ b/src/components/color-settings/color-settings.tsx
@@ -5,11 +5,9 @@
 import { useDispatch, useSelect } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
 import {
-    // @ts-ignore
     useBlockEditContext,
     // @ts-ignore
     __experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
-    // @ts-ignore
     __experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
     store as blockEditorStore,
 } from "@wordpress/block-editor";

--- a/src/components/spacing-control/index.tsx
+++ b/src/components/spacing-control/index.tsx
@@ -1,7 +1,6 @@
 /**
  * WordPress Dependencies
  */
-//@ts-ignore
 import { isEmpty } from "lodash";
 import { __ } from "@wordpress/i18n";
 import {

--- a/src/components/spacing-control/index.tsx
+++ b/src/components/spacing-control/index.tsx
@@ -8,10 +8,15 @@ import {
     useBlockEditContext,
     //@ts-ignore
     __experimentalSpacingSizesControl as SpacingSizesControl,
+    store as blockEditorStore,
 } from "@wordpress/block-editor";
 import { useSelect, useDispatch } from "@wordpress/data";
 import { __experimentalToolsPanelItem as ToolsPanelItem } from "@wordpress/components";
 import { SpacingPropTypes } from "../types";
+import {
+    BlockEditorStoreActions,
+    BlockEditorStoreSelectors,
+} from "../../wordpress__data";
 
 function SpacingControl({
     label,
@@ -20,13 +25,16 @@ function SpacingControl({
 }: SpacingPropTypes) {
     const { clientId } = useBlockEditContext();
 
-    //@ts-ignore
     const attributes = useSelect(
         (select) =>
-            //@ts-ignore
-            select("core/block-editor").getSelectedBlock().attributes
+            (
+                select(blockEditorStore) as BlockEditorStoreSelectors
+            ).getSelectedBlock()?.attributes,
+        []
     );
-    const { updateBlockAttributes } = useDispatch("core/block-editor");
+    const { updateBlockAttributes } = useDispatch(
+        blockEditorStore
+    ) as BlockEditorStoreActions;
 
     const setAttributes = (newAttributes: object) => {
         updateBlockAttributes(clientId, newAttributes);

--- a/src/components/spacing-control/index.tsx
+++ b/src/components/spacing-control/index.tsx
@@ -4,7 +4,6 @@
 import { isEmpty } from "lodash";
 import { __ } from "@wordpress/i18n";
 import {
-    //@ts-ignore
     useBlockEditContext,
     //@ts-ignore
     __experimentalSpacingSizesControl as SpacingSizesControl,

--- a/src/components/toggle-group-control/index.tsx
+++ b/src/components/toggle-group-control/index.tsx
@@ -3,13 +3,20 @@
  */
 import { useDispatch, useSelect } from "@wordpress/data";
 //@ts-ignore
-import { useBlockEditContext } from "@wordpress/block-editor";
+import {
+    useBlockEditContext,
+    store as blockEditorStore,
+} from "@wordpress/block-editor";
 import {
     __experimentalToggleGroupControl as ToggleGroupControl,
     __experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
     __experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from "@wordpress/components";
 import { ToggleGroupControlPropTypes } from "../types";
+import {
+    BlockEditorStoreActions,
+    BlockEditorStoreSelectors,
+} from "../../wordpress__data";
 
 function CustomToggleGroupControl({
     label,
@@ -20,13 +27,15 @@ function CustomToggleGroupControl({
     isDeselectable = false,
 }: ToggleGroupControlPropTypes) {
     const { clientId } = useBlockEditContext();
-    const { updateBlockAttributes } = useDispatch("core/block-editor");
+    const { updateBlockAttributes } = useDispatch(
+        blockEditorStore
+    ) as BlockEditorStoreActions;
 
-    //@ts-ignore
     const attributes = useSelect((select) => {
-        //@ts-ignore
-        return select("core/block-editor").getBlockAttributes(clientId);
-    });
+        return (
+            select(blockEditorStore) as BlockEditorStoreSelectors
+        ).getBlockAttributes(clientId);
+    }, []);
     const setAttributes = (newAttributes: object) =>
         updateBlockAttributes(clientId, newAttributes);
 

--- a/src/components/toggle-group-control/index.tsx
+++ b/src/components/toggle-group-control/index.tsx
@@ -2,7 +2,6 @@
  * WordPress Dependencies
  */
 import { useDispatch, useSelect } from "@wordpress/data";
-//@ts-ignore
 import {
     useBlockEditContext,
     store as blockEditorStore,

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -5,7 +5,7 @@ export interface BorderControlPropTypes {
     borderLabel?: string;
     attrBorderKey?: string;
     borderRadiusLabel?: string;
-    attrBorderRadiusKey?: string;
+    attrBorderRadiusKey: string;
     showBorder?: boolean;
     showBorderRadius?: boolean;
     showDefaultBorder?: boolean;

--- a/src/controls.tsx
+++ b/src/controls.tsx
@@ -112,7 +112,6 @@ function TablebergControls(props: BlockEditProps<TablebergBlockAttrs>) {
                 </PanelBody>
             </InspectorControls>
 
-            {/* @ts-ignore */}
             <InspectorControls group="styles">
                 <ToolsPanel
                     label={__("Global Font Style", "tableberg")}
@@ -157,7 +156,7 @@ function TablebergControls(props: BlockEditProps<TablebergBlockAttrs>) {
                     </ToolsPanelItem>
                 </ToolsPanel>
             </InspectorControls>
-            {/* @ts-ignore  */}
+
             <InspectorControls group="color">
                 <ColorSettingsWithGradient
                     label={__("Header Background Color", "tableberg")}
@@ -181,7 +180,6 @@ function TablebergControls(props: BlockEditProps<TablebergBlockAttrs>) {
                 />
             </InspectorControls>
 
-            {/* @ts-ignore  */}
             <InspectorControls group="dimensions">
                 <SpacingControl
                     attrKey="cellPadding"
@@ -189,7 +187,7 @@ function TablebergControls(props: BlockEditProps<TablebergBlockAttrs>) {
                     showByDefault
                 />
             </InspectorControls>
-            {/* @ts-ignore  */}
+
             <InspectorControls group="border">
                 <BorderControl
                     showDefaultBorder

--- a/src/controls.tsx
+++ b/src/controls.tsx
@@ -147,9 +147,7 @@ function TablebergControls(props: BlockEditProps<TablebergBlockAttrs>) {
                         hasValue={() => true}
                     >
                         <FontSizePicker
-                            /*
-                            // @ts-ignore*/
-                            value={attributes.fontSize}
+                            value={Number(attributes.fontSize)}
                             onChange={onFontSizeChange}
                         />
                     </ToolsPanelItem>
@@ -229,8 +227,6 @@ function TablebergControls(props: BlockEditProps<TablebergBlockAttrs>) {
             </InspectorControls>
             <BlockControls>
                 <BlockAlignmentToolbar
-                    /*
-                    // @ts-ignore*/
                     value={tableAlignment}
                     onChange={blockAlignChange}
                     controls={["left", "center", "right"]}

--- a/src/controls.tsx
+++ b/src/controls.tsx
@@ -3,7 +3,6 @@
  */
 import { __ } from "@wordpress/i18n";
 import { justifyLeft, justifyCenter, justifyRight } from "@wordpress/icons";
-//@ts-ignore
 import {
     InspectorControls,
     // @ts-ignore

--- a/src/controls.tsx
+++ b/src/controls.tsx
@@ -5,14 +5,11 @@ import { __ } from "@wordpress/i18n";
 import { justifyLeft, justifyCenter, justifyRight } from "@wordpress/icons";
 import {
     InspectorControls,
-    // @ts-ignore
     HeightControl,
     BlockControls,
     BlockAlignmentToolbar,
     FontSizePicker,
-    // @ts-ignore
     __experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
-    // @ts-ignore
     __experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 } from "@wordpress/block-editor";
 import { BlockEditProps } from "@wordpress/blocks";

--- a/src/get-classes.ts
+++ b/src/get-classes.ts
@@ -1,4 +1,3 @@
-//@ts-ignore
 import { isUndefined, trim, isEmpty } from "lodash";
 import { TablebergBlockAttrs } from "./types";
 

--- a/src/get-styles.ts
+++ b/src/get-styles.ts
@@ -1,4 +1,3 @@
-//@ts-ignore
 import { omitBy, isUndefined, trim, isEmpty, isNumber } from "lodash";
 import { getBorderVariablesCss, getSpacingCss } from "./utils/styling-helpers";
 import { PaddingTypes, TablebergBlockAttrs } from "./types";
@@ -23,7 +22,7 @@ export function getStyles(attributes: TablebergBlockAttrs) {
         enableTableHeader,
         fontColor,
         fontSize,
-        linkColor
+        linkColor,
     } = attributes;
     const cellPaddingCSS: PaddingTypes = getSpacingCss(cellPadding);
     const tableBorderVar = getBorderVariablesCss(tableBorder, "table");

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,64 @@
+declare const tablebergAdminMenuData: {
+    assets: { logo: string };
+    individual_control: {
+        data: any;
+        ajax: {
+            toggleControl: {
+                url: string;
+                action: "toggle_control";
+                nonce: string;
+            };
+        };
+    };
+    global_control: {
+        data: any;
+        ajax: {
+            toggleControl: {
+                url: string;
+                action: "toggle_control";
+                nonce: string;
+            };
+        };
+    };
+    block_properties: {
+        data: any;
+        ajax: {
+            blockProperties: {
+                url: string;
+                action: "toggle_control";
+                nonce: string;
+            };
+        };
+    };
+    welcome: {
+        title: "Welcome to Tableberg!";
+        content: "Elevate Your Content with Seamless Tables - The Ultimate WordPress Block Editor Plugin for Effortless Table Creation!";
+    };
+    documentation: {
+        title: "Documentation";
+        content: "Elevate your space with Tableberg: a sleek, modern table block for style and functionality. Crafted for timeless elegance and versatility.";
+    };
+    support: {
+        title: "Support";
+        content: "Visit our Tableberg Support Page for quick solutions and assistance. We're here to ensure your Tableberg experience is seamless and satisfying.";
+    };
+    community: {
+        title: "Join Community";
+        content: "Join the vibrant Tableberg community. Connect, share, and discover endless possibilities together. Elevate your experience with like-minded enthusiasts now!";
+    };
+    upgrade: {
+        title: "Upgrade to Tableberg PRO!";
+        content: "Elevate Your Content with Seamless Tables - The Ultimate WordPress Block Editor Plugin for Effortless Table Creation!";
+    };
+    versionControl: {
+        currentVersion: string;
+        versions: string[];
+        ajax: {
+            versionRollback: {
+                url: string;
+                action: "tableberg_version_control";
+                nonce: string;
+            };
+        };
+    };
+};

--- a/src/image/block-controls.tsx
+++ b/src/image/block-controls.tsx
@@ -9,7 +9,6 @@ import {
     // @ts-ignore
     __experimentalImageURLInputUI as ImageURLInputUI,
 } from "@wordpress/block-editor";
-//@ts-ignore
 import { usePrevious } from "@wordpress/compose";
 import { ToolbarButton, ToolbarGroup } from "@wordpress/components";
 import type { ExtendMainPropTypes } from "./types";

--- a/src/image/block-controls.tsx
+++ b/src/image/block-controls.tsx
@@ -1,4 +1,3 @@
-//@ts-ignore
 import { get } from "lodash";
 import { __ } from "@wordpress/i18n";
 //@ts-ignore

--- a/src/image/block-controls.tsx
+++ b/src/image/block-controls.tsx
@@ -47,7 +47,6 @@ function BlockControls(props: ExtendMainPropTypes) {
     }
     return (
         <>
-            {/* @ts-ignore */}
             <WPBlockControls group={"block"}>
                 <ToolbarButton
                     onClick={() => {

--- a/src/image/block-controls.tsx
+++ b/src/image/block-controls.tsx
@@ -1,7 +1,6 @@
 import { get } from "lodash";
 import { __ } from "@wordpress/i18n";
-//@ts-ignore
-import { useEffect } from "@wordpress/element";
+import { useEffect } from "react";
 import { caption as captionIcon, crop } from "@wordpress/icons";
 import {
     BlockControls as WPBlockControls,

--- a/src/image/edit.tsx
+++ b/src/image/edit.tsx
@@ -1,7 +1,6 @@
 import { isEmpty, get } from "lodash";
 import { __ } from "@wordpress/i18n";
 import { useDispatch } from "@wordpress/data";
-// @ts-ignore
 import { useState, useRef, useMemo } from "react";
 import { BlockEditProps } from "@wordpress/blocks";
 import CustomMediaPlaceholder from "./media-placeholder";

--- a/src/image/edit.tsx
+++ b/src/image/edit.tsx
@@ -9,7 +9,6 @@ import { ResizableBox } from "@wordpress/components";
 import {
     RichText,
     useBlockProps,
-    // @ts-ignore
     __experimentalGetElementClassName,
     // @ts-ignore
     __experimentalImageEditor as ImageEditor,

--- a/src/image/edit.tsx
+++ b/src/image/edit.tsx
@@ -2,7 +2,7 @@ import { isEmpty, get } from "lodash";
 import { __ } from "@wordpress/i18n";
 import { useDispatch } from "@wordpress/data";
 // @ts-ignore
-import { useState, useRef, useMemo } from "@wordpress/element";
+import { useState, useRef, useMemo } from "react";
 import { BlockEditProps } from "@wordpress/blocks";
 import CustomMediaPlaceholder from "./media-placeholder";
 import { ResizableBox } from "@wordpress/components";
@@ -139,7 +139,6 @@ function Edit(props: BlockEditProps<AttributesTypes>) {
                                         sizes: {
                                             ...media.sizes,
                                             [sizeSlug]: {
-                                                // @ts-ignore
                                                 ...media.sizes[sizeSlug],
                                                 ...imageAttributes,
                                             },

--- a/src/image/edit.tsx
+++ b/src/image/edit.tsx
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { isEmpty, get } from "lodash";
 import { __ } from "@wordpress/i18n";
 import { useDispatch } from "@wordpress/data";

--- a/src/image/image.tsx
+++ b/src/image/image.tsx
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { get } from "lodash";
 import type { ImageTypes } from "./types";
 import {

--- a/src/image/inspector.tsx
+++ b/src/image/inspector.tsx
@@ -2,8 +2,7 @@
  * Wordpress Dependencies
  */
 import { InspectorControls } from "@wordpress/block-editor";
-//@ts-ignore
-import { useMemo } from "@wordpress/element";
+import { useMemo } from "react";
 import {
     PanelBody,
     SelectControl,

--- a/src/image/inspector.tsx
+++ b/src/image/inspector.tsx
@@ -42,8 +42,7 @@ function Inspector(props: MainPropTypes) {
     const aspectRatioDisplayValue = aspectRatio ?? "auto";
     const scaleDisplayValue = scale ?? "cover";
     const scaleHelp = useMemo(() => {
-        return scaleOptions.reduce((acc, option) => {
-            //@ts-ignore
+        return scaleOptions.reduce((acc: { [key: string]: any }, option) => {
             acc[option.value] = option.help;
             return acc;
         }, {});

--- a/src/image/inspector.tsx
+++ b/src/image/inspector.tsx
@@ -195,7 +195,7 @@ function Inspector(props: MainPropTypes) {
                     </ToolsPanelItem>
                 </ToolsPanel>
             </InspectorControls>
-            {/* @ts-ignore */}
+
             <InspectorControls group="border">
                 <BorderControl
                     attrBorderKey="border"

--- a/src/image/media-placeholder.tsx
+++ b/src/image/media-placeholder.tsx
@@ -42,7 +42,6 @@ function CustomMediaPlaceholder(props: MainPropTypes) {
         <MediaPlaceholder
             icon={imageIcon}
             accept="image/*"
-            // @ts-ignore
             placeholder={placeholder}
             //  onError={onUploadError}
             onSelect={onSelectImage}

--- a/src/image/media-placeholder.tsx
+++ b/src/image/media-placeholder.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from "react";
-// @ts-ignore
 import { get, isEmpty } from "lodash";
 import { __ } from "@wordpress/i18n";
 import { Placeholder } from "@wordpress/components";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,6 +36,7 @@ import exampleImage from "./example.png";
 import {
     BlockEditorStoreActions,
     BlockEditorStoreSelectors,
+    EditorStoreSelectors,
 } from "./wordpress__data";
 
 const ALLOWED_BLOCKS = ["tableberg/row"];
@@ -135,8 +136,9 @@ function edit(props: BlockEditProps<TablebergBlockAttrs>) {
         };
 
         return {
-            // @ts-ignore
-            hasEditorRedo: select(editorStore).hasEditorRedo(),
+            hasEditorRedo: (
+                select(editorStore) as EditorStoreSelectors
+            ).hasEditorRedo(),
             removeEmptyColsOrRows,
         };
     }, []);
@@ -147,7 +149,6 @@ function edit(props: BlockEditProps<TablebergBlockAttrs>) {
         removeBlock,
         updateBlockAttributes,
     } = useDispatch(blockEditorStore) as BlockEditorStoreActions;
-    //@ts-ignore
     const tablebergData = tablebergAdminMenuData;
     const globalBlockProperties = tablebergData?.block_properties;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -76,7 +76,9 @@ function edit(props: BlockEditProps<TablebergBlockAttrs>) {
 
     const { hasEditorRedo, removeEmptyColsOrRows } = useSelect((select) => {
         const removeEmptyColsOrRows = async () => {
-            const storeSelect = select(blockEditorStore) as any;
+            const storeSelect = select(
+                blockEditorStore
+            ) as BlockEditorStoreSelectors;
             const rows = storeSelect.getBlocks(clientId);
 
             /**

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,8 +2,6 @@
  * WordPress Imports
  */
 import { isEmpty, get, last } from "lodash";
-//@ts-ignore
-import { useEffect } from "@wordpress/element";
 import { Placeholder, TextControl, Button } from "@wordpress/components";
 import { blockTable } from "@wordpress/icons";
 import { useDispatch, useSelect } from "@wordpress/data";
@@ -26,7 +24,7 @@ import {
  */
 import "./style.scss";
 import metadata from "./block.json";
-import { FormEvent, useState } from "react";
+import { FormEvent, useState, useEffect } from "react";
 import TablebergControls from "./controls";
 import { TablebergBlockAttrs } from "./types";
 import { getStyles } from "./get-styles";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
 /**
  * WordPress Imports
  */
-//@ts-ignore
 import { isEmpty, get, last } from "lodash";
 //@ts-ignore
 import { useEffect } from "@wordpress/element";
@@ -58,7 +57,6 @@ function edit(props: BlockEditProps<TablebergBlockAttrs>) {
         className: classNames(getStyleClass(props.attributes)),
         style: getStyles(props.attributes),
     });
-    
 
     // @ts-ignore
     const innerBlocksProps = useInnerBlocksProps(blockProps, {

--- a/src/row/index.tsx
+++ b/src/row/index.tsx
@@ -14,6 +14,7 @@ import { useSelect } from "@wordpress/data";
 
 import metadata from "./block.json";
 import classNames from "classnames";
+import { BlockEditorStoreSelectors } from "../wordpress__data";
 
 interface TBRowAttrs {
     tagName: string;
@@ -33,7 +34,9 @@ function edit({ clientId, attributes }: BlockEditProps<TBRowAttrs>) {
 
     const hasInnerBlocks = useSelect(
         (select) =>
-            (select(blockEditorStore) as any).getBlocks(clientId).length > 0,
+            (select(blockEditorStore) as BlockEditorStoreSelectors).getBlocks(
+                clientId
+            ).length > 0,
         [clientId]
     );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface TablebergBlockAttrs {
     tableWidth: string;
     enableTableHeader: boolean;
     enableTableFooter: boolean;
-    tableAlignment: string;
+    tableAlignment: "center" | "full" | "left" | "right" | "wide";
     cellPadding: PaddingTypes;
     headerBackgroundColor: string | null;
     headerBackgroundGradient: string | null;

--- a/src/utils/styling-helpers.ts
+++ b/src/utils/styling-helpers.ts
@@ -103,14 +103,11 @@ export function getSpacingPresetCssVar(value: string) {
 }
 
 export function getSpacingCss(object: object) {
-    let css = {};
-    //@ts-ignore
+    let css: { [key: string]: any } = {};
     for (const [key, value] of Object.entries(object)) {
         if (isValueSpacingPreset(value)) {
-            //@ts-ignore
             css[key] = getSpacingPresetCssVar(value);
         } else {
-            //@ts-ignore
             css[key] = value;
         }
     }

--- a/src/utils/styling-helpers.ts
+++ b/src/utils/styling-helpers.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { isEmpty, has } from "lodash";
 import { __experimentalHasSplitBorders as hasSplitBorders } from "@wordpress/components";
 import { BorderTypes } from "./common-types";

--- a/src/utils/styling-helpers.ts
+++ b/src/utils/styling-helpers.ts
@@ -31,12 +31,16 @@ export function getSingleSideBorderValue(
 
 export function getBorderVariablesCss(border: object, slug: string) {
     const borderInFourDimension = getBorderCSS(border);
-    const borderSides = ["top", "right", "bottom", "left"];
+    const borderSides: Array<keyof BorderTypes> = [
+        "top",
+        "right",
+        "bottom",
+        "left",
+    ];
     let borders = {};
     for (let i = 0; i < borderSides.length; i++) {
         const side = borderSides[i];
         const sideProperty = [`--tableberg-${slug}-border-${side}`];
-        // @ts-ignore
         const sideValue = getSingleSideBorderValue(borderInFourDimension, side);
         // @ts-ignore
         borders[sideProperty] = sideValue;

--- a/src/wordpress__block-editor.d.ts
+++ b/src/wordpress__block-editor.d.ts
@@ -22,4 +22,10 @@ declare module "@wordpress/block-editor" {
             group?: "block" | "other";
         }
     }
+
+    const useBlockEditContext: () => {
+        name: string;
+        isSelected: boolean;
+        clientId: string;
+    };
 }

--- a/src/wordpress__block-editor.d.ts
+++ b/src/wordpress__block-editor.d.ts
@@ -28,7 +28,7 @@ declare module "@wordpress/block-editor" {
             children?: never | undefined;
             onChange(newValue: string | undefined): void;
             value: string | undefined;
-            label: string;
+            label?: string;
         }
     }
 

--- a/src/wordpress__block-editor.d.ts
+++ b/src/wordpress__block-editor.d.ts
@@ -88,6 +88,23 @@ declare module "@wordpress/block-editor" {
 
     const __experimentalLinkControl: import("react").ComponentType<__experimentalLinkControl.Props>;
 
+    namespace __experimentalBorderRadiusControl {
+        interface Props {
+            children?: never | undefined;
+            values:
+                | string
+                | {
+                      topLeft: string;
+                      topRight: string;
+                      bottomLeft: string;
+                      bottomRight: string;
+                  };
+            onChange: (newValue: object) => void;
+        }
+    }
+
+    const __experimentalBorderRadiusControl: import("react").ComponentType<__experimentalBorderRadiusControl.Props>;
+
     const useBlockEditContext: () => {
         name: string;
         isSelected: boolean;

--- a/src/wordpress__block-editor.d.ts
+++ b/src/wordpress__block-editor.d.ts
@@ -117,4 +117,26 @@ declare module "@wordpress/block-editor" {
             [key: string]: string;
         };
     };
+
+    const __experimentalUseMultipleOriginColorsAndGradients: () => {
+        colors: {
+            name: string;
+            colors: {
+                name: string;
+                slug: string;
+                color: string;
+            }[];
+        }[];
+        disableCustomColors: boolean;
+        disableCustomGradients: boolean;
+        gradients: {
+            name: string;
+            gradients: {
+                gradient: string;
+                name: string;
+                slug: string;
+            }[];
+        }[];
+        hasColorsOrGradients: boolean;
+    };
 }

--- a/src/wordpress__block-editor.d.ts
+++ b/src/wordpress__block-editor.d.ts
@@ -103,6 +103,12 @@ declare module "@wordpress/block-editor" {
         }
     }
 
+    namespace MediaPlaceholder {
+        interface Props<T extends boolean> {
+            placeholder: (content: import("react").ReactNode) => JSX.Element;
+        }
+    }
+
     const __experimentalBorderRadiusControl: import("react").ComponentType<__experimentalBorderRadiusControl.Props>;
 
     const useBlockEditContext: () => {

--- a/src/wordpress__block-editor.d.ts
+++ b/src/wordpress__block-editor.d.ts
@@ -54,6 +54,40 @@ declare module "@wordpress/block-editor" {
 
     const AlignmentControl: import("react").ComponentType<AlignmentControl.Props>;
 
+    namespace __experimentalLinkControl {
+        interface LinkControlValue {
+            url?: string;
+            opensInNewTab?: boolean;
+        }
+        interface Props {
+            children?: never | undefined;
+            searchInputPlaceholder?: string;
+            value: LinkControlValue;
+            settings?: {
+                id: string;
+                title: string;
+            };
+            onChange?: (newValue: LinkControlValue) => void;
+            onRemove?: () => void;
+            onCancel?: () => void;
+            noDirectEntry?: boolean;
+            showSuggestions?: boolean;
+            showInitialSuggestions?: boolean;
+            forceIsEditingLink?: boolean;
+            createSuggestion?: boolean;
+            withCreateSuggestion?: boolean;
+            inputValue?: string;
+            suggestionsQuery?: object;
+            noURLSuggestion?: boolean;
+            createSuggestionButtonText?: string | (() => string);
+            hasRichPreviews?: boolean;
+            hasTextControl?: boolean;
+            renderControlBottom?: any;
+        }
+    }
+
+    const __experimentalLinkControl: import("react").ComponentType<__experimentalLinkControl.Props>;
+
     const useBlockEditContext: () => {
         name: string;
         isSelected: boolean;

--- a/src/wordpress__block-editor.d.ts
+++ b/src/wordpress__block-editor.d.ts
@@ -145,4 +145,6 @@ declare module "@wordpress/block-editor" {
         }[];
         hasColorsOrGradients: boolean;
     };
+
+    const __experimentalGetElementClassName: (element: string) => string;
 }

--- a/src/wordpress__block-editor.d.ts
+++ b/src/wordpress__block-editor.d.ts
@@ -1,4 +1,5 @@
 import "@wordpress/block-editor";
+import { BlockAttributes } from "@wordpress/blocks";
 
 declare module "@wordpress/block-editor" {
     namespace InspectorControls {
@@ -57,5 +58,12 @@ declare module "@wordpress/block-editor" {
         name: string;
         isSelected: boolean;
         clientId: string;
+    };
+
+    const __experimentalUseBorderProps: (attributes: BlockAttributes) => {
+        className: string;
+        style: {
+            [key: string]: string;
+        };
     };
 }

--- a/src/wordpress__block-editor.d.ts
+++ b/src/wordpress__block-editor.d.ts
@@ -34,6 +34,25 @@ declare module "@wordpress/block-editor" {
 
     const HeightControl: import("react").ComponentType<HeightControl.Props>;
 
+    namespace AlignmentControl {
+        interface Props {
+            children?: never | undefined;
+            onChange(newValue: string | undefined): void;
+            value: string | undefined;
+            label?: string;
+            alignmentControls?: {
+                align: string;
+                icon: JSX.Element;
+                title: string;
+            }[];
+            describedBy?: string;
+            isCollapsed?: boolean;
+            isToolbar?: boolean;
+        }
+    }
+
+    const AlignmentControl: import("react").ComponentType<AlignmentControl.Props>;
+
     const useBlockEditContext: () => {
         name: string;
         isSelected: boolean;

--- a/src/wordpress__block-editor.d.ts
+++ b/src/wordpress__block-editor.d.ts
@@ -1,0 +1,25 @@
+import "@wordpress/block-editor";
+
+declare module "@wordpress/block-editor" {
+    namespace InspectorControls {
+        interface Props {
+            group?:
+                | "default"
+                | "settings"
+                | "advanced"
+                | "position"
+                | "border"
+                | "color"
+                | "dimensions"
+                | "typography"
+                | "styles"
+                | "list";
+        }
+    }
+
+    namespace BlockControls {
+        interface Props {
+            group?: "block" | "other";
+        }
+    }
+}

--- a/src/wordpress__block-editor.d.ts
+++ b/src/wordpress__block-editor.d.ts
@@ -23,6 +23,17 @@ declare module "@wordpress/block-editor" {
         }
     }
 
+    namespace HeightControl {
+        interface Props {
+            children?: never | undefined;
+            onChange(newValue: string | undefined): void;
+            value: string | undefined;
+            label: string;
+        }
+    }
+
+    const HeightControl: import("react").ComponentType<HeightControl.Props>;
+
     const useBlockEditContext: () => {
         name: string;
         isSelected: boolean;


### PR DESCRIPTION
Changes made:
* removed unnecessary `@ts-ignore` comments
* replaced untyped imports with typed imports (e.g. change imports from `@wordpress/element` to `react`)
* installed type package for untyped package
* added types for missing react components
* added types for missing functions
* added types for missing props
* fixed type errors
* fixed type definitions
* added global variable type