### PR TITLE
Fix: adding header footer bug

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -166,7 +166,7 @@ function edit(props: BlockEditProps<TablebergBlockAttrs>) {
                 [
                     "tableberg/row",
                     { isHeader: true },
-                    new Array(initialColCount)
+                    new Array(props.attributes.cols ?? initialColCount)
                         .fill(0)
                         .map(() => ["tableberg/cell", { tagName: "th" }, []]),
                 ],
@@ -191,7 +191,7 @@ function edit(props: BlockEditProps<TablebergBlockAttrs>) {
                 [
                     "tableberg/row",
                     { isFooter: true },
-                    new Array(initialColCount)
+                    new Array(props.attributes.cols ?? initialColCount)
                         .fill(0)
                         .map(() => ["tableberg/cell", { tagName: "th" }, []]),
                 ],


### PR DESCRIPTION
Bug: Adds exactly 3 columns when header/footer is enabled despite the actual column count.