### PR TITLE
Theme palette support for color controls.

### DIFF
--- a/packages/components/editor/ColorControl.tsx
+++ b/packages/components/editor/ColorControl.tsx
@@ -28,7 +28,7 @@ function ColorSetting({
     colorValue,
     gradientValue,
     label,
-    palette,
+    palette = "theme",
     onColorChange,
     onGradientChange,
     onDeselect,


### PR DESCRIPTION
**Background**: There was an issue with block color controls where theme colors are not being displayed as palette.

**Solution Summary**: A default value not being supplied caused the issue.

**ScreenShots**: 
Before: ![Before](https://github.com/user-attachments/assets/c1cfc0b1-ba20-4046-b031-4765459fd54c)

After: ![After](https://github.com/user-attachments/assets/85918780-1de9-4b20-a6d2-ad80ede51863)